### PR TITLE
Mrc 6462 - add zoom layer

### DIFF
--- a/src/layers/Layer.ts
+++ b/src/layers/Layer.ts
@@ -12,7 +12,7 @@ export enum LayerType {
   ClipPath = "clipPath",
   BaseLayer = "baseLayer",
   Axes = "axes",
-  Brush = "brush",
+  Zoom = "zoom",
   Trace = "trace",
   Tooltip = "tooltip"
 }

--- a/src/layers/ZoomLayer.ts
+++ b/src/layers/ZoomLayer.ts
@@ -2,7 +2,7 @@ import * as d3 from "@/d3";
 import { D3Selection, LayerArgs, LayerType, OptionalLayer, Point, ZoomExtents, CustomEvents } from "./Layer";
 
 export class ZoomLayer extends OptionalLayer {
-  type = LayerType.Brush;
+  type = LayerType.Zoom;
 
   constructor() {
     super();
@@ -17,7 +17,7 @@ export class ZoomLayer extends OptionalLayer {
 
     layerArgs.coreLayers[LayerType.Svg].dispatch(CustomEvents.AnimationStart);
     layerArgs.optionalLayers.forEach(layer => {
-      if (layer.type === LayerType.Brush) return;
+      if (layer.type === LayerType.Zoom) return;
       layer.doZoom(zoomExtents);
     });
     setTimeout(() => {
@@ -48,7 +48,7 @@ export class ZoomLayer extends OptionalLayer {
     const d3Brush = d3.brushX<Point>()
       .extent([[margin.left, margin.top], [width - margin.right, height - margin.bottom]]);
     const brushLayer = layerArgs.coreLayers[LayerType.BaseLayer].append("g")
-      .attr("id", layerArgs.getHtmlId(LayerType.Brush))
+      .attr("id", layerArgs.getHtmlId(LayerType.Zoom))
       .call(d3Brush);
     d3Brush.on("end", e => {
       this.handleBrushEnd(e, brushLayer, layerArgs);

--- a/src/layers/ZoomLayer.ts
+++ b/src/layers/ZoomLayer.ts
@@ -10,6 +10,8 @@ export class ZoomLayer extends OptionalLayer {
 
   private handleZoom = (zoomExtents: ZoomExtents, layerArgs: LayerArgs) => {
     const { x: scaleX, y: scaleY } = layerArgs.scaleConfig.linearScales;
+    // updates the scales which are implicitly used by a lot of other
+    // components
     if (zoomExtents.x) scaleX.domain(zoomExtents.x);
     if (zoomExtents.y) scaleY.domain(zoomExtents.y);
 
@@ -41,6 +43,8 @@ export class ZoomLayer extends OptionalLayer {
   draw = (layerArgs: LayerArgs) => {
     const { width, height, margin } = layerArgs.bounds;
     
+    // brushX allows the user to click and draw a rectangle that will
+    // select a particular x interval and it will then fire an end event
     const d3Brush = d3.brushX<Point>()
       .extent([[margin.left, margin.top], [width - margin.right, height - margin.bottom]]);
     const brushLayer = layerArgs.coreLayers[LayerType.BaseLayer].append("g")

--- a/src/layers/ZoomLayer.ts
+++ b/src/layers/ZoomLayer.ts
@@ -56,6 +56,7 @@ export class ZoomLayer extends OptionalLayer {
     });
     d3Brush.on("start", () => layerArgs.coreLayers[LayerType.Svg].dispatch(CustomEvents.BrushStart));
 
+    // Respond to double click event by fully zooming out
     const { x } = layerArgs.scaleConfig.scaleExtents;
     layerArgs.coreLayers[LayerType.Svg].on("dblclick",() => this.handleZoom({ x: [x.start, x.end] }, layerArgs));
   };

--- a/src/layers/ZoomLayer.ts
+++ b/src/layers/ZoomLayer.ts
@@ -1,0 +1,58 @@
+import * as d3 from "@/d3";
+import { D3Selection, LayerArgs, LayerType, OptionalLayer, Point, ZoomExtents, CustomEvents } from "./Layer";
+
+export class ZoomLayer extends OptionalLayer {
+  type = LayerType.Brush;
+
+  constructor() {
+    super();
+  };
+
+  private handleZoom = (zoomExtents: ZoomExtents, layerArgs: LayerArgs) => {
+    const { x: scaleX, y: scaleY } = layerArgs.scaleConfig.linearScales;
+    if (zoomExtents.x) scaleX.domain(zoomExtents.x);
+    if (zoomExtents.y) scaleY.domain(zoomExtents.y);
+
+    layerArgs.coreLayers[LayerType.Svg].dispatch(CustomEvents.AnimationStart);
+    layerArgs.optionalLayers.forEach(layer => {
+      if (layer.type === LayerType.Brush) return;
+      layer.doZoom(zoomExtents);
+    });
+    setTimeout(() => {
+      layerArgs.coreLayers[LayerType.Svg].dispatch(CustomEvents.AnimationEnd);
+    }, layerArgs.globals.animationDuration);
+  };
+
+  private handleBrushEnd = (event: d3.D3BrushEvent<Point>, brushLayer: D3Selection<SVGGElement>, layerArgs: LayerArgs) => {
+    const extent = event.selection as [number, number];
+    if (!extent) return;
+
+    // removes the grey area of the brush
+    brushLayer.call(event.target.move as any, null);
+
+    const scaleX = layerArgs.scaleConfig.linearScales.x;
+    const lExtent = scaleX.invert(extent[0]);
+    const rExtent = scaleX.invert(extent[1]);
+
+    if (Math.abs(lExtent - rExtent) < 5) return;
+    this.handleZoom({ x: [lExtent, rExtent] }, layerArgs);
+  };
+
+  draw = (layerArgs: LayerArgs) => {
+    const { width, height, margin } = layerArgs.bounds;
+    
+    const d3Brush = d3.brushX<Point>()
+      .extent([[margin.left, margin.top], [width - margin.right, height - margin.bottom]]);
+    const brushLayer = layerArgs.coreLayers[LayerType.BaseLayer].append("g")
+      .attr("id", layerArgs.getHtmlId(LayerType.Brush))
+      .call(d3Brush);
+    d3Brush.on("end", e => {
+      this.handleBrushEnd(e, brushLayer, layerArgs);
+      layerArgs.coreLayers[LayerType.Svg].dispatch(CustomEvents.BrushEnd);
+    });
+    d3Brush.on("start", () => layerArgs.coreLayers[LayerType.Svg].dispatch(CustomEvents.BrushStart));
+
+    const { x } = layerArgs.scaleConfig.scaleExtents;
+    layerArgs.coreLayers[LayerType.Svg].on("dblclick",() => this.handleZoom({ x: [x.start, x.end] }, layerArgs));
+  };
+};


### PR DESCRIPTION
Also does what it says on the tin, in a nutshell, it adds a brush layer where users can select a boundary and then updates the scales, then it calls `doZoom` on every optional layer.