### PR TITLE
Mrc 6463 - Add final chart class

### DIFF
--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -99,6 +99,7 @@ export class Chart {
       optionalLayers: []
     };
 
+    // Clear any existing content in the element
     baseElement.childNodes.forEach(n => n.remove());
 
     this.optionalLayers.forEach(l => {

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -1,0 +1,149 @@
+import * as d3 from "./d3";
+import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, LayerType, Point, XY } from "./layers/Layer";
+import { AxesLayer } from "./layers/AxesLayer";
+import { TracesLayer } from "./layers/TracesLayer";
+import { ZoomLayer } from "./layers/ZoomLayer";
+import { TooltipHtmlCallback, TooltipsLayer } from "./layers/TooltipsLayer";
+
+export type Scales = XY<{ start: number, end: number }>
+
+type LineConfig = {
+  points: Point[],
+  style: {
+    color?: string,
+    opacity?: number,
+    strokeWidth?: number
+  }
+}
+export type Lines = LineConfig[]
+
+export class Chart {
+  id: string;
+  optionalLayers: AllOptionalLayers[] = [];
+  isResponsive: boolean = false;
+  globals = {
+    animationDuration: 350
+  };
+
+  constructor(public scales: Scales) {
+    this.id = Math.random().toString(26).substring(2, 10);
+
+    return this;
+  };
+
+  addAxes = () => {
+    this.optionalLayers.push(new AxesLayer());
+    return this;
+  };
+
+  addTraces = (lines: Lines) => {
+    this.optionalLayers.push(new TracesLayer(lines));
+    return this;
+  };
+
+  addZoom = () => {
+    this.optionalLayers.push(new ZoomLayer());
+    return this;
+  };
+
+  addTooltips = (tooltipHtmlCallback: TooltipHtmlCallback) => {
+    this.optionalLayers.push(new TooltipsLayer(tooltipHtmlCallback));
+    return this;
+  };
+
+  makeResponsive = () => {
+    this.isResponsive = true;
+    return this;
+  };
+
+  private draw = (baseElement: HTMLDivElement, bounds: Bounds) => {
+    const getHtmlId = (layer: LayerType[keyof LayerType]) => `${layer}-${this.id}`;
+    const { height, width, margin } = bounds;
+ 
+    const svg = d3.create("svg")
+      .attr("id", getHtmlId(LayerType.Svg))
+      .attr("width", "100%")
+      .attr("height", "100%")
+      .attr("viewBox", `0 0 ${width} ${height}`)
+      .attr("preserveAspectRatio", "xMinYMin")
+      .attr("vector-effect", "non-scaling-stroke") as any as D3Selection<SVGSVGElement>;
+
+    const clipPath = svg.append("defs")
+      .append("svg:clipPath")
+      .attr("id", getHtmlId(LayerType.ClipPath)) as any as D3Selection<SVGClipPathElement>;
+    clipPath.append("svg:rect")
+      .attr("vector-effect", "non-scaling-stroke")
+      .attr("width", width - margin.right - margin.left)
+      .attr("height", height - margin.bottom - margin.top)
+      .attr("x", margin.left)
+      .attr("y", margin.top);
+
+    const baseLayer = svg.append('g')
+      .attr("id", getHtmlId(LayerType.BaseLayer))
+      .attr("vector-effect", "non-scaling-stroke")
+      .attr("clip-path", `url(#${getHtmlId(LayerType.ClipPath)})`);
+
+    const { x, y } = this.scales;
+    const scaleX = d3.scaleLinear()
+      .domain([x.start, x.end])
+      .range([ margin.left, width - margin.right ]);
+    const scaleY = d3.scaleLinear()
+      .domain([y.start, y.end])
+      .range([ height - margin.bottom, margin.top ]);
+    
+    const lineGen = d3.line<Point>()
+      .x(d => scaleX(d.x))
+      .y(d => scaleY(d.y));
+
+    const layerArgs: LayerArgs = {
+      id: this.id,
+      getHtmlId,
+      bounds,
+      globals: this.globals,
+      scaleConfig: {
+        linearScales: { x: scaleX, y: scaleY },
+        lineGen,
+        scaleExtents: this.scales
+      },
+      coreLayers: {
+        [LayerType.Svg]: svg,
+        [LayerType.ClipPath]: clipPath,
+        [LayerType.BaseLayer]: baseLayer
+      },
+      optionalLayers: []
+    };
+
+    baseElement.childNodes.forEach(n => n.remove());
+
+    this.optionalLayers.forEach(l => {
+      l.draw(layerArgs);
+      layerArgs.optionalLayers.push(l);
+    });
+
+    baseElement.append(layerArgs.coreLayers[LayerType.Svg].node()!);
+  };
+
+  appendTo = (baseElement: HTMLDivElement) => {
+    const defaultMargin = { top: 20, bottom: 20, left: 40, right: 40 };
+    const drawWithBounds = (width: number, height: number) => {
+      const bounds = { width, height, margin: defaultMargin };
+      this.draw(baseElement, bounds);
+    };
+
+    const { width, height } = baseElement.getBoundingClientRect();
+    drawWithBounds(width, height);
+
+    if (this.isResponsive) {
+      const resizeObserver = new ResizeObserver(entries => {
+        const { blockSize: height, inlineSize: width } = entries[0].borderBoxSize[0];
+        drawWithBounds(width, height);
+      });
+      resizeObserver.observe(baseElement);
+      window.addEventListener("resize", e => {
+        if (!e.view) return;
+        const { innerHeight: height, innerWidth: width } = e.view;
+        drawWithBounds(width, height);
+      });
+    }
+  };
+};

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -1,21 +1,10 @@
 import * as d3 from "./d3";
-import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, LayerType, Point, XY } from "./layers/Layer";
 import { AxesLayer } from "./layers/AxesLayer";
 import { TracesLayer } from "./layers/TracesLayer";
 import { ZoomLayer } from "./layers/ZoomLayer";
 import { TooltipHtmlCallback, TooltipsLayer } from "./layers/TooltipsLayer";
-
-export type Scales = XY<{ start: number, end: number }>
-
-type LineConfig = {
-  points: Point[],
-  style: {
-    color?: string,
-    opacity?: number,
-    strokeWidth?: number
-  }
-}
-export type Lines = LineConfig[]
+import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, Point, Scales } from "./types";
+import { LayerType } from "./layers/Layer";
 
 export class Chart {
   id: string;
@@ -65,14 +54,12 @@ export class Chart {
       .attr("width", "100%")
       .attr("height", "100%")
       .attr("viewBox", `0 0 ${width} ${height}`)
-      .attr("preserveAspectRatio", "xMinYMin")
-      .attr("vector-effect", "non-scaling-stroke") as any as D3Selection<SVGSVGElement>;
+      .attr("preserveAspectRatio", "xMinYMin") as any as D3Selection<SVGSVGElement>;
 
     const clipPath = svg.append("defs")
       .append("svg:clipPath")
       .attr("id", getHtmlId(LayerType.ClipPath)) as any as D3Selection<SVGClipPathElement>;
     clipPath.append("svg:rect")
-      .attr("vector-effect", "non-scaling-stroke")
       .attr("width", width - margin.right - margin.left)
       .attr("height", height - margin.bottom - margin.top)
       .attr("x", margin.left)
@@ -80,7 +67,6 @@ export class Chart {
 
     const baseLayer = svg.append('g')
       .attr("id", getHtmlId(LayerType.BaseLayer))
-      .attr("vector-effect", "non-scaling-stroke")
       .attr("clip-path", `url(#${getHtmlId(LayerType.ClipPath)})`);
 
     const { x, y } = this.scales;
@@ -134,11 +120,16 @@ export class Chart {
     drawWithBounds(width, height);
 
     if (this.isResponsive) {
+      // watch for changes in baseElement
       const resizeObserver = new ResizeObserver(entries => {
         const { blockSize: height, inlineSize: width } = entries[0].borderBoxSize[0];
         drawWithBounds(width, height);
       });
       resizeObserver.observe(baseElement);
+
+      // above resizeObserver was not triggering when maximising
+      // browser window for example so this event listener watches
+      // for changes to the window itself
       window.addEventListener("resize", e => {
         if (!e.view) return;
         const { innerHeight: height, innerWidth: width } = e.view;

--- a/src/layers/AxesLayer.ts
+++ b/src/layers/AxesLayer.ts
@@ -1,5 +1,6 @@
 import * as d3 from "@/d3";
-import { LayerArgs, LayerType, OptionalLayer } from "./Layer";
+import { LayerType, OptionalLayer } from "./Layer";
+import { LayerArgs } from "@/types";
 
 export class AxesLayer extends OptionalLayer {
   type = LayerType.Axes;
@@ -21,7 +22,6 @@ export class AxesLayer extends OptionalLayer {
     const axisLayerX = svgLayer.append("g")
       .attr("id", `${getHtmlId(LayerType.Axes)}-x`)
       .attr("transform", `translate(0,${height - margin.bottom})`)
-      .attr("vector-effect", "non-scaling-stroke")
       .call(axisX);
 
     let defaultTicksY = 10;
@@ -31,7 +31,6 @@ export class AxesLayer extends OptionalLayer {
     const axisLayerY = svgLayer.append("g")
       .attr("id", `${getHtmlId(LayerType.Axes)}-y`)
       .attr("transform", `translate(${margin.left},0)`)
-      .attr("vector-effect", "non-scaling-stroke")
       .call(axisY);
 
     // The zoom layer (if added) will update the scaleX and scaleY

--- a/src/layers/Layer.ts
+++ b/src/layers/Layer.ts
@@ -1,5 +1,4 @@
-import { Scales } from "@/Chart";
-import * as d3 from "@/d3";
+import { LayerArgs, ZoomExtents } from "@/types";
 
 /*
   These are the various different types of layer types
@@ -29,54 +28,6 @@ export enum CustomEvents {
   AnimationStart = "animationstart",
   AnimationEnd = "animationend",
 }
-
-export type XY<T> = { x: T, y: T }
-
-export type Point = XY<number>
-
-/*
-  These are bounds of the svg element
-*/
-export type Bounds = {
-  width: number,
-  height: number,
-  margin: {
-    top: number, bottom: number,
-    left: number, right: number
-  }
-}
-
-export type D3Selection<Element extends d3.BaseType> = d3.Selection<Element, Point, null, undefined>
-
-export type AllOptionalLayers = OptionalLayer<any>;
-
-/*
-  LayerArgs are passed into each Layer in the draw
-  function. This happens at the last step when users
-  append the svg to a base element
-*/
-export type LayerArgs = {
-  // TODO chart id instead
-  id: string,
-  getHtmlId: (layer: LayerType) => string,
-  bounds: Bounds,
-  globals: {
-    animationDuration: number
-  },
-  scaleConfig: {
-    linearScales: XY<d3.ScaleLinear<number, number, never>>,
-    scaleExtents: Scales,
-    lineGen: d3.Line<Point>
-  },
-  coreLayers: {
-    [LayerType.Svg]: D3Selection<SVGSVGElement>,
-    [LayerType.ClipPath]: D3Selection<SVGClipPathElement>,
-    [LayerType.BaseLayer]: D3Selection<SVGGElement>,
-  },
-  optionalLayers: AllOptionalLayers[]
-};
-
-export type ZoomExtents = Partial<XY<[number, number]>>
 
 export abstract class OptionalLayer<Properties = null> {
   abstract type: LayerType;

--- a/src/layers/TracesLayer.ts
+++ b/src/layers/TracesLayer.ts
@@ -1,5 +1,5 @@
-import { Lines } from "@/Chart";
-import { LayerArgs, LayerType, OptionalLayer } from "./Layer";
+import { LayerArgs, Lines } from "@/types";
+import { LayerType, OptionalLayer } from "./Layer";
 
 export class TracesLayer extends OptionalLayer {
   type = LayerType.Trace;
@@ -14,7 +14,6 @@ export class TracesLayer extends OptionalLayer {
       return layerArgs.coreLayers[LayerType.BaseLayer].append("path")
         .attr("id", `${layerArgs.getHtmlId(LayerType.Trace)}-${index}`)
         .attr("pointer-events", "none")
-        .attr("vector-effect", "non-scaling-stroke")
         .attr("fill", "none")
         .attr("stroke", l.style.color || "black")
         .attr("opacity", l.style.opacity || 1)

--- a/src/layers/ZoomLayer.ts
+++ b/src/layers/ZoomLayer.ts
@@ -1,5 +1,6 @@
 import * as d3 from "@/d3";
-import { D3Selection, LayerArgs, LayerType, OptionalLayer, Point, ZoomExtents, CustomEvents } from "./Layer";
+import { LayerType, OptionalLayer, CustomEvents } from "./Layer";
+import { D3Selection, LayerArgs, Point, ZoomExtents } from "@/types";
 
 export class ZoomLayer extends OptionalLayer {
   type = LayerType.Zoom;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,62 @@
+import * as d3 from "./d3";
+import { LayerType, OptionalLayer } from "./layers/Layer";
+
+export type XY<T> = { x: T, y: T }
+
+export type Point = XY<number>
+
+/*
+  These are bounds of the svg element
+*/
+export type Bounds = {
+  width: number,
+  height: number,
+  margin: {
+    top: number, bottom: number,
+    left: number, right: number
+  }
+}
+
+export type D3Selection<Element extends d3.BaseType> = d3.Selection<Element, Point, null, undefined>
+
+export type AllOptionalLayers = OptionalLayer<any>;
+
+/*
+  LayerArgs are passed into each Layer in the draw
+  function. This happens at the last step when users
+  append the svg to a base element
+*/
+export type LayerArgs = {
+  // TODO chart id instead
+  id: string,
+  getHtmlId: (layer: LayerType) => string,
+  bounds: Bounds,
+  globals: {
+    animationDuration: number
+  },
+  scaleConfig: {
+    linearScales: XY<d3.ScaleLinear<number, number, never>>,
+    scaleExtents: Scales,
+    lineGen: d3.Line<Point>
+  },
+  coreLayers: {
+    [LayerType.Svg]: D3Selection<SVGSVGElement>,
+    [LayerType.ClipPath]: D3Selection<SVGClipPathElement>,
+    [LayerType.BaseLayer]: D3Selection<SVGGElement>,
+  },
+  optionalLayers: AllOptionalLayers[]
+};
+
+export type ZoomExtents = Partial<XY<[number, number]>>
+export type Scales = XY<{ start: number, end: number }>
+
+type LineConfig = {
+  points: Point[],
+  style: {
+    color?: string,
+    opacity?: number,
+    strokeWidth?: number
+  }
+}
+export type Lines = LineConfig[]
+


### PR DESCRIPTION
This finally brings everything together (ignore the `TooltipLayer` for now, i have intentionally left that after this because it is the most complicated)

In the constructor we only generate out the id, and in the add functions we mostly just push a layer into optional layers. The main chuck of the work happen in the draw function where the core d3 elements are created (these are the base for our other components) and `layerArgs` are constructed (what we pass into every layer's draw function) 