### PR TITLE
Mrc 6485 Add axes labels and grid lines

### DIFF
--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -1,39 +1,10 @@
 <template>
-  <h1>Basic traces (spark lines)</h1>
-  <div class="chart" ref="chartSparkLines"></div>
-
-  <h1>Chart with axes</h1>
-  <div class="chart" ref="chartOnlyAxes"></div>
-
-  <h1>Axes and gridlines</h1>
-  <div class="chart" ref="chartAxesAndGrid"></div>
-
-  <h1>Axes, labels and gridlines</h1>
-  <div class="chart" ref="chartAxesLabelsAndGrid"></div>
-
-  <h1>Traces, gridlines, axes, labels and zoom</h1>
-  <div class="chart" ref="chartAxesLabelGridAndZoom"></div>
-
-  <h1>Chart with tooltips</h1>
-  <div class="chart" ref="chartTooltips"></div>
-
-  <h1>Responsive chart</h1>
-  <div class="chart-responsive" ref="chartResponsive"></div>
-
-  <h1>Stress test: 1000 traces</h1>
-  <button @click="drawStressChart">Draw</button>
-  <div class="chart" ref="chartStress"></div>
+  <div style="height: 55vh; width: 75vw;" ref="chart" class="bordered"></div>
 </template>
 
-<style>
-.chart {
-  width: 1000px;
-  height: 500px;
-}
-
-.chart-responsive {
-  width: 60vw;
-  height: 55vh;
+<style lang="css" scoped>
+.bordered {
+  border: solid black 1px;
 }
 </style>
 
@@ -41,59 +12,40 @@
 import { Chart, Lines, Scales } from "../skadi-chart";
 import { onMounted, ref } from "vue";
 
-const chartSparkLines = ref<HTMLDivElement | null>(null);
-const chartOnlyAxes = ref<HTMLDivElement | null>(null);
-const chartAxesAndGrid = ref<HTMLDivElement | null>(null);
-const chartAxesLabelsAndGrid = ref<HTMLDivElement | null>(null);
-const chartAxesLabelGridAndZoom = ref<HTMLDivElement | null>(null);
-const chartTooltips = ref<HTMLDivElement | null>(null);
-const chartResponsive = ref<HTMLDivElement | null>(null);
-const chartStress = ref<HTMLDivElement | null>(null);
+const chart = ref<HTMLDivElement | null>(null);
 
-const propsBasic = {
-  nX: 1000,
-  nL: 10,
-  ampScaling: 3,
-  freqRange: 0.1,
-  freqOffset: 0.95,
-  phaseRange: 0.5,
-  phaseOffset: 0.25,
-  opacityRange: 0.2,
-  opacityOffset: 0.8,
-  strokeWidthRange: 0.1,
-  strokeWidthOffset: 0.9,
-}
+// can safely ignore all generating code, it just allows me to easily make
+// pretty pictures
+// 
+// only important ones are nX and nL, number of points per line and number of
+// lines
+const nX = 1000;
+const nL = 1000;
 
-const propsStress = {
-  nX: 1000,
-  nL: 1000,
-  ampScaling: 3,
-  freqRange: 0.1,
-  freqOffset: 0.95,
-  phaseRange: 0.5,
-  phaseOffset: 0.25,
-  opacityRange: 0.15,
-  opacityOffset: 0.01,
-  strokeWidthRange: 0.4,
-  strokeWidthOffset: 0,
-}
+const ampScaling = 3;
+const freqRange = 0.1;
+const freqOffset = 0.95;
+const phaseRange = 0.5;
+const phaseOffset = 0.25;
+const opacityRange = 0.5;
+const opacityOffset = 0.2;
 
-const makeRandomCurves = (props: typeof propsBasic) => {
-  const xPoints = Array.from({length: props.nX + 1}, (_, i) => i / props.nX);
+const makeRandomCurves = () => {
+  const xPoints = Array.from({length: nX + 1}, (_, i) => i / nX);
   const lines: Lines = [];
   const makeYFunc = () => {
     const amp1 = Math.random();
     const amp2 = Math.random();
     const amp3 = Math.random();
     const amp4 = Math.random();
-    const freq1 = Math.random() * props.freqRange + props.freqOffset;
-    const freq2 = Math.random() * props.freqRange + props.freqOffset;
-    const freq3 = Math.random() * props.freqRange + props.freqOffset;
-    const freq4 = Math.random() * props.freqRange + props.freqOffset;
-    const phase1 = Math.random() * props.phaseRange + props.phaseOffset;
-    const phase2 = Math.random() * props.phaseRange + props.phaseOffset;
-    const phase3 = Math.random() * props.phaseRange + props.phaseOffset;
-    const phase4 = Math.random() * props.phaseRange + props.phaseOffset;
+    const freq1 = Math.random() * freqRange + freqOffset;
+    const freq2 = Math.random() * freqRange + freqOffset;
+    const freq3 = Math.random() * freqRange + freqOffset;
+    const freq4 = Math.random() * freqRange + freqOffset;
+    const phase1 = Math.random() * phaseRange + phaseOffset;
+    const phase2 = Math.random() * phaseRange + phaseOffset;
+    const phase3 = Math.random() * phaseRange + phaseOffset;
+    const phase4 = Math.random() * phaseRange + phaseOffset;
     return (x: number) => {
       return amp1 * Math.sin(freq1 * 53 * x + phase1)
         + amp2 * Math.cos(freq2 * 31 * x + phase2)
@@ -103,24 +55,32 @@ const makeRandomCurves = (props: typeof propsBasic) => {
   };
 
   // rainbow
-  const colors = [ "#e81416", "#ffa500", "#faeb36", "#79c314", "#487de7", "#4b369d", "#70369d" ];
+  const colors = [
+    "#e81416",
+    "#ffa500",
+    "#faeb36",
+    "#79c314",
+    "#487de7",
+    "#4b369d",
+    "#70369d"
+  ];
 
   const randomIndex = (length: number) => {
     return Math.floor(Math.random() * length);
   };
 
-  for (let l = 0; l < props.nL; l++) {
+  for (let l = 0; l < nL; l++) {
     const line: Lines[number] = {
       points: [],
       style: {
-        opacity: Math.random() * props.opacityRange + props.opacityOffset,
+        opacity: Math.random() * opacityRange + opacityOffset,
         color: colors[randomIndex(colors.length)],
-        strokeWidth: Math.random() * 1
+        strokeWidth: Math.random() * 0.5
       }
     };
     const yfunc = makeYFunc();
-    for (let i = 0; i < props.nX + 1; i++) {
-      line.points.push({ x: xPoints[i], y: yfunc(xPoints[i]) * props.ampScaling });
+    for (let i = 0; i < nX + 1; i++) {
+      line.points.push({ x: xPoints[i], y: yfunc(xPoints[i]) * ampScaling });
     }
     lines.push(line);
   }
@@ -128,68 +88,17 @@ const makeRandomCurves = (props: typeof propsBasic) => {
 };
 
 const tooltipHtmlCallback = (point: {x: number, y: number}) => {
-  return `X: ${point.x.toFixed(3)}, Y: ${point.y.toFixed(3)}`;
-};
-
-const curvesSparkLines = makeRandomCurves(propsBasic);
-const curvesOnlyAxes = makeRandomCurves(propsBasic);
-const curvesAxesAndGrid = makeRandomCurves(propsBasic);
-const curvesAxesLabelsAndGrid = makeRandomCurves(propsBasic);
-const curvesAxesLabelGridAndZoom = makeRandomCurves(propsBasic);
-const curvesTooltips = makeRandomCurves(propsBasic);
-const curvesResponsive = makeRandomCurves(propsBasic);
-const curvesStress = makeRandomCurves(propsStress);
-
-const scales: Scales = { x: {start: 0, end: 1}, y: {start: -10, end: 10} };
-
-const drawStressChart = () => {
-  new Chart(scales)
-    .addZoom()
-    .addTraces(curvesStress)
-    .addAxes()
-    .addTooltips(tooltipHtmlCallback)
-    .appendTo(chartStress.value!);
+  return `X: ${point.x}, Y: ${point.y}`;
 };
 
 onMounted(async () => {
+  const scales: Scales = { x: {start: 0, end: 1}, y: {start: -10, end: 10} };
   new Chart(scales)
-    .addTraces(curvesSparkLines)
-    .appendTo(chartSparkLines.value!);
-
-  new Chart(scales)
-    .addTraces(curvesOnlyAxes)
-    .addAxes()
-    .appendTo(chartOnlyAxes.value!);
-
-  new Chart(scales)
-    .addTraces(curvesAxesAndGrid)
-    .addAxes()
-    .addGridLines()
-    .appendTo(chartAxesAndGrid.value!);
-
-  new Chart(scales)
-    .addTraces(curvesAxesLabelsAndGrid)
-    .addAxes({ x: "Time", y: "Value" })
-    .addGridLines()
-    .appendTo(chartAxesLabelsAndGrid.value!);
-
-  new Chart(scales)
-    .addTraces(curvesAxesLabelGridAndZoom)
-    .addAxes({ x: "Time", y: "Value" })
-    .addGridLines()
     .addZoom()
-    .appendTo(chartAxesLabelGridAndZoom.value!);
-
-  new Chart(scales)
-    .addTraces(curvesTooltips)
-    .addTooltips(tooltipHtmlCallback)
-    .appendTo(chartTooltips.value!);
-
-  new Chart(scales)
-    .addTraces(curvesResponsive)
+    .addTraces(makeRandomCurves())
     .addAxes()
-    .addGridLines()
     .makeResponsive()
-    .appendTo(chartResponsive.value!);
+    .addTooltips(tooltipHtmlCallback)
+    .appendTo(chart.value!)
 });
 </script>

--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -1,10 +1,39 @@
 <template>
-  <div style="height: 55vh; width: 75vw;" ref="chart" class="bordered"></div>
+  <h1>Basic traces (spark lines)</h1>
+  <div class="chart" ref="chartSparkLines"></div>
+
+  <h1>Chart with axes</h1>
+  <div class="chart" ref="chartOnlyAxes"></div>
+
+  <h1>Axes and gridlines</h1>
+  <div class="chart" ref="chartAxesAndGrid"></div>
+
+  <h1>Axes, labels and gridlines</h1>
+  <div class="chart" ref="chartAxesLabelsAndGrid"></div>
+
+  <h1>Traces, gridlines, axes, labels and zoom</h1>
+  <div class="chart" ref="chartAxesLabelGridAndZoom"></div>
+
+  <h1>Chart with tooltips</h1>
+  <div class="chart" ref="chartTooltips"></div>
+
+  <h1>Responsive chart</h1>
+  <div class="chart-responsive" ref="chartResponsive"></div>
+
+  <h1>Stress test: 1000 traces</h1>
+  <button @click="drawStressChart">Draw</button>
+  <div class="chart" ref="chartStress"></div>
 </template>
 
-<style lang="css" scoped>
-.bordered {
-  border: solid black 1px;
+<style>
+.chart {
+  width: 1000px;
+  height: 500px;
+}
+
+.chart-responsive {
+  width: 60vw;
+  height: 55vh;
 }
 </style>
 
@@ -12,40 +41,59 @@
 import { Chart, Lines, Scales } from "../skadi-chart";
 import { onMounted, ref } from "vue";
 
-const chart = ref<HTMLDivElement | null>(null);
+const chartSparkLines = ref<HTMLDivElement | null>(null);
+const chartOnlyAxes = ref<HTMLDivElement | null>(null);
+const chartAxesAndGrid = ref<HTMLDivElement | null>(null);
+const chartAxesLabelsAndGrid = ref<HTMLDivElement | null>(null);
+const chartAxesLabelGridAndZoom = ref<HTMLDivElement | null>(null);
+const chartTooltips = ref<HTMLDivElement | null>(null);
+const chartResponsive = ref<HTMLDivElement | null>(null);
+const chartStress = ref<HTMLDivElement | null>(null);
 
-// can safely ignore all generating code, it just allows me to easily make
-// pretty pictures
-// 
-// only important ones are nX and nL, number of points per line and number of
-// lines
-const nX = 1000;
-const nL = 1000;
+const propsBasic = {
+  nX: 1000,
+  nL: 10,
+  ampScaling: 3,
+  freqRange: 0.1,
+  freqOffset: 0.95,
+  phaseRange: 0.5,
+  phaseOffset: 0.25,
+  opacityRange: 0.2,
+  opacityOffset: 0.8,
+  strokeWidthRange: 0.1,
+  strokeWidthOffset: 0.9,
+}
 
-const ampScaling = 3;
-const freqRange = 0.1;
-const freqOffset = 0.95;
-const phaseRange = 0.5;
-const phaseOffset = 0.25;
-const opacityRange = 0.5;
-const opacityOffset = 0.2;
+const propsStress = {
+  nX: 1000,
+  nL: 1000,
+  ampScaling: 3,
+  freqRange: 0.1,
+  freqOffset: 0.95,
+  phaseRange: 0.5,
+  phaseOffset: 0.25,
+  opacityRange: 0.15,
+  opacityOffset: 0.01,
+  strokeWidthRange: 0.4,
+  strokeWidthOffset: 0,
+}
 
-const makeRandomCurves = () => {
-  const xPoints = Array.from({length: nX + 1}, (_, i) => i / nX);
+const makeRandomCurves = (props: typeof propsBasic) => {
+  const xPoints = Array.from({length: props.nX + 1}, (_, i) => i / props.nX);
   const lines: Lines = [];
   const makeYFunc = () => {
     const amp1 = Math.random();
     const amp2 = Math.random();
     const amp3 = Math.random();
     const amp4 = Math.random();
-    const freq1 = Math.random() * freqRange + freqOffset;
-    const freq2 = Math.random() * freqRange + freqOffset;
-    const freq3 = Math.random() * freqRange + freqOffset;
-    const freq4 = Math.random() * freqRange + freqOffset;
-    const phase1 = Math.random() * phaseRange + phaseOffset;
-    const phase2 = Math.random() * phaseRange + phaseOffset;
-    const phase3 = Math.random() * phaseRange + phaseOffset;
-    const phase4 = Math.random() * phaseRange + phaseOffset;
+    const freq1 = Math.random() * props.freqRange + props.freqOffset;
+    const freq2 = Math.random() * props.freqRange + props.freqOffset;
+    const freq3 = Math.random() * props.freqRange + props.freqOffset;
+    const freq4 = Math.random() * props.freqRange + props.freqOffset;
+    const phase1 = Math.random() * props.phaseRange + props.phaseOffset;
+    const phase2 = Math.random() * props.phaseRange + props.phaseOffset;
+    const phase3 = Math.random() * props.phaseRange + props.phaseOffset;
+    const phase4 = Math.random() * props.phaseRange + props.phaseOffset;
     return (x: number) => {
       return amp1 * Math.sin(freq1 * 53 * x + phase1)
         + amp2 * Math.cos(freq2 * 31 * x + phase2)
@@ -55,32 +103,24 @@ const makeRandomCurves = () => {
   };
 
   // rainbow
-  const colors = [
-    "#e81416",
-    "#ffa500",
-    "#faeb36",
-    "#79c314",
-    "#487de7",
-    "#4b369d",
-    "#70369d"
-  ];
+  const colors = [ "#e81416", "#ffa500", "#faeb36", "#79c314", "#487de7", "#4b369d", "#70369d" ];
 
   const randomIndex = (length: number) => {
     return Math.floor(Math.random() * length);
   };
 
-  for (let l = 0; l < nL; l++) {
+  for (let l = 0; l < props.nL; l++) {
     const line: Lines[number] = {
       points: [],
       style: {
-        opacity: Math.random() * opacityRange + opacityOffset,
+        opacity: Math.random() * props.opacityRange + props.opacityOffset,
         color: colors[randomIndex(colors.length)],
-        strokeWidth: Math.random() * 0.5
+        strokeWidth: Math.random() * 1
       }
     };
     const yfunc = makeYFunc();
-    for (let i = 0; i < nX + 1; i++) {
-      line.points.push({ x: xPoints[i], y: yfunc(xPoints[i]) * ampScaling });
+    for (let i = 0; i < props.nX + 1; i++) {
+      line.points.push({ x: xPoints[i], y: yfunc(xPoints[i]) * props.ampScaling });
     }
     lines.push(line);
   }
@@ -88,17 +128,68 @@ const makeRandomCurves = () => {
 };
 
 const tooltipHtmlCallback = (point: {x: number, y: number}) => {
-  return `X: ${point.x}, Y: ${point.y}`;
+  return `X: ${point.x.toFixed(3)}, Y: ${point.y.toFixed(3)}`;
+};
+
+const curvesSparkLines = makeRandomCurves(propsBasic);
+const curvesOnlyAxes = makeRandomCurves(propsBasic);
+const curvesAxesAndGrid = makeRandomCurves(propsBasic);
+const curvesAxesLabelsAndGrid = makeRandomCurves(propsBasic);
+const curvesAxesLabelGridAndZoom = makeRandomCurves(propsBasic);
+const curvesTooltips = makeRandomCurves(propsBasic);
+const curvesResponsive = makeRandomCurves(propsBasic);
+const curvesStress = makeRandomCurves(propsStress);
+
+const scales: Scales = { x: {start: 0, end: 1}, y: {start: -10, end: 10} };
+
+const drawStressChart = () => {
+  new Chart(scales)
+    .addZoom()
+    .addTraces(curvesStress)
+    .addAxes()
+    .addTooltips(tooltipHtmlCallback)
+    .appendTo(chartStress.value!);
 };
 
 onMounted(async () => {
-  const scales: Scales = { x: {start: 0, end: 1}, y: {start: -10, end: 10} };
   new Chart(scales)
-    .addZoom()
-    .addTraces(makeRandomCurves())
+    .addTraces(curvesSparkLines)
+    .appendTo(chartSparkLines.value!);
+
+  new Chart(scales)
+    .addTraces(curvesOnlyAxes)
     .addAxes()
-    .makeResponsive()
+    .appendTo(chartOnlyAxes.value!);
+
+  new Chart(scales)
+    .addTraces(curvesAxesAndGrid)
+    .addAxes()
+    .addGridLines()
+    .appendTo(chartAxesAndGrid.value!);
+
+  new Chart(scales)
+    .addTraces(curvesAxesLabelsAndGrid)
+    .addAxes({ x: "Time", y: "Value" })
+    .addGridLines()
+    .appendTo(chartAxesLabelsAndGrid.value!);
+
+  new Chart(scales)
+    .addTraces(curvesAxesLabelGridAndZoom)
+    .addAxes({ x: "Time", y: "Value" })
+    .addGridLines()
+    .addZoom()
+    .appendTo(chartAxesLabelGridAndZoom.value!);
+
+  new Chart(scales)
+    .addTraces(curvesTooltips)
     .addTooltips(tooltipHtmlCallback)
-    .appendTo(chart.value!)
+    .appendTo(chartTooltips.value!);
+
+  new Chart(scales)
+    .addTraces(curvesResponsive)
+    .addAxes()
+    .addGridLines()
+    .makeResponsive()
+    .appendTo(chartResponsive.value!);
 });
 </script>

--- a/src/layers/AxesLayer.ts
+++ b/src/layers/AxesLayer.ts
@@ -1,11 +1,11 @@
 import * as d3 from "@/d3";
 import { LayerType, OptionalLayer } from "./Layer";
-import { LayerArgs } from "@/types";
+import { LayerArgs, XYLabel } from "@/types";
 
 export class AxesLayer extends OptionalLayer {
   type = LayerType.Axes;
 
-  constructor() {
+  constructor(public labels: XYLabel) {
     super();
   };
 
@@ -14,32 +14,42 @@ export class AxesLayer extends OptionalLayer {
     const { x: scaleX, y: scaleY } = layerArgs.scaleConfig.linearScales;
     const svgLayer = layerArgs.coreLayers[LayerType.Svg];
     const { getHtmlId } = layerArgs;
+    const { animationDuration, ticks } = layerArgs.globals;
 
-    let defaultTicksX = 10;
-    if (width < 500) defaultTicksX = 6;
-    if (width < 300) defaultTicksX = 3;
-    const axisX = d3.axisBottom(scaleX).ticks(defaultTicksX);
+    const axisX = d3.axisBottom(scaleX).ticks(ticks.x).tickSize(0).tickPadding(8);
     const axisLayerX = svgLayer.append("g")
       .attr("id", `${getHtmlId(LayerType.Axes)}-x`)
       .attr("transform", `translate(0,${height - margin.bottom})`)
       .call(axisX);
 
-    let defaultTicksY = 10;
-    if (height < 400) defaultTicksY = 6;
-    if (height < 200) defaultTicksY = 3;
-    const axisY = d3.axisLeft(scaleY).ticks(defaultTicksY);
+    const axisY = d3.axisLeft(scaleY).ticks(ticks.y).tickSize(0).tickPadding(8);
     const axisLayerY = svgLayer.append("g")
       .attr("id", `${getHtmlId(LayerType.Axes)}-y`)
       .attr("transform", `translate(${margin.left},0)`)
       .call(axisY);
+
+    if (this.labels.y) {
+      layerArgs.coreLayers[LayerType.Svg].append("text")
+        .attr("text-anchor", "middle")
+        .attr("x", - (height - margin.top - margin.bottom) / 2 - margin.top)
+        .attr("y", margin.left / 2)
+        .attr("transform", "rotate(-90)")
+        .text(this.labels.y)
+    }
+
+    if (this.labels.x) {
+      layerArgs.coreLayers[LayerType.Svg].append("text")
+        .attr("text-anchor", "middle")
+        .attr("x", (width - margin.left - margin.right) / 2 + margin.left)
+        .attr("y", layerArgs.bounds.height - margin.bottom / 3)
+        .text(this.labels.x)
+    }
 
     // The zoom layer (if added) will update the scaleX and scaleY
     // so axisY and axisX, which are constructed from these will
     // also update. This function just specifies a smooth transition
     // between the old and new values of the scales
     this.zoom = async () => {
-      const { animationDuration } = layerArgs.globals;
-
       const promiseX = axisLayerX.transition()
         .duration(animationDuration)
         .call(axisX)

--- a/src/layers/GridLayer.ts
+++ b/src/layers/GridLayer.ts
@@ -1,0 +1,77 @@
+import { D3Selection, LayerArgs } from "@/types";
+import { LayerType, OptionalLayer } from "./Layer";
+
+export class GridLayer extends OptionalLayer {
+  type = LayerType.Grid;
+
+  constructor() {
+    super();
+  };
+
+  draw = (layerArgs: LayerArgs) => {
+    const { width, height, margin } = layerArgs.bounds;
+    const { x: scaleX, y: scaleY } = layerArgs.scaleConfig.linearScales;
+    const svgLayer = layerArgs.coreLayers[LayerType.Svg];
+    const { animationDuration, ticks } = layerArgs.globals;
+  
+    const addGridX = (g: D3Selection<SVGGElement>) => {
+      g.selectAll("line")
+        .data(scaleX.ticks(ticks.x))
+        .join("line")
+        .style("stroke", "grey")
+        .attr("x1", (d: number) => scaleX(d))
+        .attr("x2", (d: number) => scaleX(d))
+        .attr("y1", margin.top)
+        .attr("y2", height - margin.bottom)
+    };
+
+    const addGridY = (g: D3Selection<SVGGElement>) => {
+      g.selectAll("line")
+        .data(scaleY.ticks(ticks.y))
+        .join("line")
+        .style("stroke", "grey")
+        .attr("x1", margin.left)
+        .attr("x2", width - margin.right)
+        .attr("y1", (d: number) => scaleY(d))
+        .attr("y2", (d: number) => scaleY(d))
+    };
+
+    const gridX = svgLayer.append("g")
+      .call(addGridX)
+      .attr("opacity", 0.3);
+
+    const gridY = svgLayer.append("g")
+      .call(addGridY)
+      .attr("opacity", 0.3);
+
+    this.zoom = async () => {
+      const fadeOutX = gridX.selectAll("line")
+        .transition()
+        .duration(animationDuration / 2)
+        .style("opacity", 0)
+        .remove()
+        .end();
+      const fadeOutY = gridY.selectAll("line")
+        .transition()
+        .duration(animationDuration / 2)
+        .style("opacity", 0)
+        .remove()
+        .end();
+      await Promise.all([fadeOutX, fadeOutY]);
+
+      const fadeInX = gridX.call(addGridX)
+        .style("opacity", 0)
+        .transition()
+        .duration(animationDuration / 2)
+        .style("opacity", 0.3)
+        .end();
+      const fadeInY = gridY.call(addGridY)
+        .style("opacity", 0)
+        .transition()
+        .duration(animationDuration / 2)
+        .style("opacity", 0.3)
+        .end();
+      await Promise.all([fadeInX, fadeInY]);
+    };
+  };
+}

--- a/src/layers/Layer.ts
+++ b/src/layers/Layer.ts
@@ -13,7 +13,8 @@ export enum LayerType {
   Axes = "axes",
   Zoom = "zoom",
   Trace = "trace",
-  Tooltip = "tooltip"
+  Tooltip = "tooltip",
+  Grid = "grid",
 }
 
 /*

--- a/src/skadi-chart.ts
+++ b/src/skadi-chart.ts
@@ -1,3 +1,4 @@
-import { Chart, Lines, Scales } from "./Chart";
+import { Chart } from "./Chart";
+import { Lines, Scales } from "./types";
 export { Chart };
 export type { Lines, Scales }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,8 @@ export type XY<T> = { x: T, y: T }
 
 export type Point = XY<number>
 
+export type XYLabel = Partial<XY<string>>
+
 /*
   These are bounds of the svg element
 */
@@ -32,7 +34,8 @@ export type LayerArgs = {
   getHtmlId: (layer: LayerType) => string,
   bounds: Bounds,
   globals: {
-    animationDuration: number
+    animationDuration: number,
+    ticks: XY<number>
   },
   scaleConfig: {
     linearScales: XY<d3.ScaleLinear<number, number, never>>,


### PR DESCRIPTION
for the axes labels:
* i added them to the axes layer as that felt most appropriate and people can specify either label, if a label is specified then we increase the margins of the svg to allow room for the text

for the gridlines:
* these line up with the ticks on the axes, which means that i need that information in the grid layer, so I moved the logic for number of ticks into `Chart` class and expose the number of ticks as a global variable
* the animation for the axes is like an actual zoom, the axes stretch, the old ticks fade out and the new ones fade in, unfortunately theres no easy way to replicate this and keep the grid lines lined up with the axes ticks when we animate zoom in. So i decided to take a simpler approach and fade out the old grid lines and fade in the new ones, i think this looks acceptable