### PR TITLE
Mrc 6582 Export to png function in every chart class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
         "d3-transition": "^3.0.1",
+        "html2canvas": "^1.4.1",
         "vue": "^3.5.13"
       },
       "devDependencies": {
@@ -2018,6 +2019,14 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/birpc": {
       "version": "0.2.19",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.19.tgz",
@@ -2244,6 +2253,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssstyle": {
@@ -3072,6 +3089,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -4306,6 +4335,14 @@
         "node": ">=18"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4464,6 +4501,14 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.2.0",
     "d3-transition": "^3.0.1",
+    "html2canvas": "^1.4.1",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -6,6 +6,7 @@ import { TooltipHtmlCallback, TooltipsLayer } from "./layers/TooltipsLayer";
 import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, Point, Scales, XYLabel } from "./types";
 import { LayerType } from "./layers/Layer";
 import { GridLayer } from "./layers/GridLayer";
+import html2canvas from "html2canvas";
 
 export class Chart {
   id: string;
@@ -16,6 +17,7 @@ export class Chart {
     ticks: { x: 0, y: 0 }
   };
   defaultMargin = { top: 20, bottom: 35, left: 50, right: 20 };
+  exportToPng: ((name?: string) => void) | null = null;
 
   constructor(public scales: Scales) {
     this.id = Math.random().toString(26).substring(2, 10);
@@ -154,6 +156,17 @@ export class Chart {
         drawWithBounds(width, height);
       });
     }
+
+    this.exportToPng = async (name: string = "graph.png") => {
+      const canvas = await html2canvas(baseElement);
+      const image = canvas.toDataURL("image/png");
+      const link = document.createElement("a");
+      link.download = name;
+      link.href = `data:${image}`;
+      link.click();
+      link.remove();
+    }
+
     return this;
   };
 };

--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -13,6 +13,7 @@
 
   <h1>Traces, gridlines, axes, labels and zoom</h1>
   <div class="chart" ref="chartAxesLabelGridAndZoom" id="chartAxesLabelGridAndZoom"></div>
+  <button @click="() => exportToPng!('zoomPlot.png')">Download PNG</button>
 
   <h1>Chart with tooltips</h1>
   <div class="chart" ref="chartTooltips" id="chartTooltips"></div>
@@ -151,6 +152,8 @@ const drawStressChart = () => {
     .appendTo(chartStress.value!);
 };
 
+const exportToPng = ref<(name?: string) => void>();
+
 onMounted(async () => {
   const axesLAbels = { x: "Time", y: "Value" };
   new Chart(scales)
@@ -174,12 +177,13 @@ onMounted(async () => {
     .addGridLines()
     .appendTo(chartAxesLabelsAndGrid.value!);
 
-  new Chart(scales)
+  const chart = new Chart(scales)
     .addTraces(curvesAxesLabelGridAndZoom)
     .addAxes(axesLAbels)
     .addGridLines()
     .addZoom()
     .appendTo(chartAxesLabelGridAndZoom.value!);
+  exportToPng.value = chart.exportToPng!;
 
   new Chart(scales)
     .addTraces(curvesTooltips)

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -156,3 +156,10 @@ test("basic traces and tooltips", async ({ page }) => {
     .expectTooltip()
     .end()
 });
+
+test("download button works as expected", async ({ page }) => {
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByText("Download PNG").click({ force: true });
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe("zoomPlot.png");
+});


### PR DESCRIPTION
this uses the html2canvas library to first render the dom using canvas, then we convert the canvas element to png and finally we download the file

i chose to export the function rather than add an on hover button like plotly because i think this is more flexible, we may want the button to be more visible or we may want to have a download all button where we call multiple image downloads, or we can achieve the on hover button ourselves very easily but it doesnt feel like the job of the graphing library to make such ui decisions