### PR TITLE
Mrc 6584 simplify by removing customevents

### DIFF
--- a/src/layers/Layer.ts
+++ b/src/layers/Layer.ts
@@ -17,17 +17,6 @@ export enum LayerType {
   Grid = "grid",
 }
 
-/*
-  We need some custom events so that layers can listen
-  to events (such as turning off tooltips when brushing).
-  To keep it simple, all these events will be
-  dispatched on the svg element
-*/
-export enum CustomEvents {
-  ZoomStart = "zoomstart",
-  ZoomEnd = "zoomend",
-}
-
 export abstract class OptionalLayer<Properties = null> {
   abstract type: LayerType;
   properties: Properties | null = null;
@@ -36,7 +25,12 @@ export abstract class OptionalLayer<Properties = null> {
 
   abstract draw(layerArgs: LayerArgs): void;
 
+  // brush lifecycle hooks
+  // note: brushEnd is the same as beforeZoom
+  brushStart() {};
+
   // zoom lifecycle hooks
   beforeZoom(_zoomExtents: ZoomExtents) {};
   async zoom(_zoomExtents: ZoomExtents) {};
+  afterZoom() {};
 };

--- a/src/layers/TooltipsLayer.ts
+++ b/src/layers/TooltipsLayer.ts
@@ -1,5 +1,5 @@
 import * as d3 from "@/d3";
-import { LayerType, OptionalLayer, CustomEvents } from "./Layer";
+import { LayerType, OptionalLayer } from "./Layer";
 import { TracesLayer } from "./TracesLayer";
 import { D3Selection, LayerArgs, Point, XY } from "@/types";
 
@@ -151,16 +151,14 @@ export class TooltipsLayer extends OptionalLayer {
       }
     });
 
-    const hideTooltipCallback = () => {
+    this.brushStart = () => {
       hideTooltip = true;
       tooltip.html("");
     };
-    const showTooltipCallback = () => {
+    this.afterZoom = () => {
       hideTooltip = false;
     };
 
-    svg.on(CustomEvents.ZoomStart, hideTooltipCallback);
-    svg.on(CustomEvents.ZoomEnd, showTooltipCallback);
     svg.on("mouseleave", () => tooltip.remove());
     svg.on("mouseenter", () => document.body.append(tooltip.node()!));
   };

--- a/src/layers/ZoomLayer.ts
+++ b/src/layers/ZoomLayer.ts
@@ -1,5 +1,5 @@
 import * as d3 from "@/d3";
-import { LayerType, OptionalLayer, CustomEvents } from "./Layer";
+import { LayerType, OptionalLayer } from "./Layer";
 import { D3Selection, LayerArgs, Point, ZoomExtents } from "@/types";
 
 export class ZoomLayer extends OptionalLayer {
@@ -48,7 +48,7 @@ export class ZoomLayer extends OptionalLayer {
     layerArgs.optionalLayers.forEach(layer => promises.push(layer.zoom(zoomExtents)));
     await Promise.all(promises);
 
-    layerArgs.coreLayers[LayerType.Svg].dispatch(CustomEvents.ZoomEnd);
+    layerArgs.optionalLayers.forEach(layer => layer.afterZoom());
     this.zooming = false;
   };
 
@@ -80,7 +80,7 @@ export class ZoomLayer extends OptionalLayer {
 
     // if it is more than a 500x zoom we don't zoom
     if (Math.abs(extentXStart - extentXEnd) < minDistX || Math.abs(extentYStart - extentYEnd) < minDistY) {
-      layerArgs.coreLayers[LayerType.Svg].dispatch(CustomEvents.ZoomEnd);
+      layerArgs.optionalLayers.forEach(layer => layer.afterZoom());
       return;
     };
     this.handleZoom({ x: [extentXStart, extentXEnd], y: [extentYStart, extentYEnd] }, layerArgs);
@@ -151,7 +151,7 @@ export class ZoomLayer extends OptionalLayer {
       .style("mask-composite", "subtract") as any as D3Selection<SVGRectElement>;
     
 
-    d3Brush.on("start", () => layerArgs.coreLayers[LayerType.Svg].dispatch(CustomEvents.ZoomStart));
+    d3Brush.on("start", () => layerArgs.optionalLayers.forEach(l => l.brushStart()));
     d3Brush.on("brush", e => this.handleBrushMove(e, layerArgs));
     d3Brush.on("end", e => this.handleBrushEnd(e, brushLayer, layerArgs));
 


### PR DESCRIPTION
we replace custom events with layer lifecycle hooks, it does the exact same thing just more consistent!