### PR TITLE
Mrc 6640 Add metadata to tooltips and points

### DIFF
--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -24,7 +24,7 @@ type PartialChartOptions = {
   logScale?: Partial<XY<boolean>>
 }
 
-export class Chart {
+export class Chart<Metadata = any> {
   id: string;
   optionalLayers: AllOptionalLayers[] = [];
   isResponsive: boolean = false;
@@ -65,13 +65,13 @@ export class Chart {
   // segments, missing out the points with values <= 0. Here we create a line
   // segment and iterate down the points of a line and once we hit a negative
   // coordinate we push that line segment and start a new one
-  private filterLinesForLogAxis = (lines: Lines, axis: "x" | "y") => {
+  private filterLinesForLogAxis = (lines: Lines<Metadata>, axis: "x" | "y") => {
     let warningMsg = "";
-    const filteredPoints: Lines = [];
+    const filteredPoints: Lines<Metadata> = [];
     for (let i = 0; i < lines.length; i++) {
       const currLine = lines[i];
       let isLastCoordinatePositive = currLine.points[0] && currLine.points[0][axis] > 0;
-      let lineSegment: Lines[number] = { points: [], style: currLine.style };
+      let lineSegment: Lines<Metadata>[number] = { points: [], style: currLine.style };
 
       for (let j = 0; j < currLine.points.length; j++) {
         if (currLine.points[j][axis] <= 0) {
@@ -98,7 +98,7 @@ export class Chart {
     return filteredPoints;
   };
 
-  private filterLines = (lines: Lines) => {
+  private filterLines = (lines: Lines<Metadata>) => {
     let filteredLines = lines;
     if (this.options.logScale.x) {
       filteredLines = this.filterLinesForLogAxis(filteredLines, "x");
@@ -109,7 +109,7 @@ export class Chart {
     return filteredLines;
   };
 
-  addTraces = (lines: Lines, options?: Partial<TracesOptions>) => {
+  addTraces = (lines: Lines<Metadata>, options?: Partial<TracesOptions>) => {
     const optionsWithDefaults: TracesOptions = {
       RDPEpsilon: options?.RDPEpsilon ?? null
     };
@@ -126,12 +126,12 @@ export class Chart {
     return this;
   };
 
-  addTooltips = (tooltipHtmlCallback: TooltipHtmlCallback) => {
+  addTooltips = (tooltipHtmlCallback: TooltipHtmlCallback<Metadata>) => {
     this.optionalLayers.push(new TooltipsLayer(tooltipHtmlCallback));
     return this;
   };
 
-  private filterScatterPointsForLogAxis = (points: ScatterPoints, axis: "x" | "y") => {
+  private filterScatterPointsForLogAxis = (points: ScatterPoints<Metadata>, axis: "x" | "y") => {
     const filteredPoints = points.filter(p => p[axis] > 0);
     if (filteredPoints.length !== points.length) {
       console.warn(
@@ -143,7 +143,7 @@ export class Chart {
     return filteredPoints;
   };
 
-  private filterScatterPoints = (points: ScatterPoints) => {
+  private filterScatterPoints = (points: ScatterPoints<Metadata>) => {
     let filteredPoints = points;
     if (this.options.logScale.x) {
       filteredPoints = this.filterScatterPointsForLogAxis(filteredPoints, "x");
@@ -154,7 +154,7 @@ export class Chart {
     return filteredPoints;
   }
 
-  addScatterPoints = (points: ScatterPoints) => {
+  addScatterPoints = (points: ScatterPoints<Metadata>) => {
     const filteredPoints = this.filterScatterPoints(points);
     this.optionalLayers.push(new ScatterLayer(filteredPoints));
     return this;
@@ -211,8 +211,10 @@ export class Chart {
   };
 
   private processScales = (partialScales: PartialScales): Scales => {
-    const traceLayers = this.optionalLayers.filter(l => l.type === LayerType.Trace) as TracesLayer[];
-    const scatterLayers = this.optionalLayers.filter(l => l.type === LayerType.Scatter) as ScatterLayer[];
+    const traceLayers = this.optionalLayers
+      .filter(l => l.type === LayerType.Trace) as TracesLayer<Metadata>[];
+    const scatterLayers = this.optionalLayers
+      .filter(l => l.type === LayerType.Scatter) as ScatterLayer<Metadata>[];
     let flatPointsDC = traceLayers.reduce((points, layer) => {
       return [...layer.linesDC.map(l => l.points).flat(), ...points];
     }, [] as Point[]);

--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -133,9 +133,11 @@ const randomIndex = (length: number) => {
   return Math.floor(Math.random() * length);
 };
 
+type Metadata = { color: string }
+
 const makeRandomPoints = (props: typeof pointPropsBasic) => {
   const xPoints = Array.from({length: props.n + 1}, () => Math.random());
-  const points: ScatterPoints = [];
+  const points: ScatterPoints<Metadata> = [];
   const y = () => {
     const rand = (Math.random() - 0.5) * 2;
     const e = rand * rand * rand;
@@ -143,13 +145,15 @@ const makeRandomPoints = (props: typeof pointPropsBasic) => {
   };
 
   for (let i = 0; i < props.n; i++) {
-    const scatterPoint: ScatterPoints[number] = {
+    const color = colors[randomIndex(colors.length)];
+    const scatterPoint: ScatterPoints<Metadata>[number] = {
       x: xPoints[i], y: y(),
       style: {
         radius: Math.random() * props.radiusRange + props.radiusOffset,
-        color: colors[randomIndex(colors.length)],
+        color,
         opacity: Math.random() * props.opacityRange + props.opacityOffset
-      }
+      },
+      metadata: { color }
     };
     points.push(scatterPoint);
   }
@@ -158,7 +162,7 @@ const makeRandomPoints = (props: typeof pointPropsBasic) => {
 
 const makeRandomCurves = (props: typeof propsBasic) => {
   const xPoints = Array.from({length: props.nX + 1}, (_, i) => i / props.nX);
-  const lines: Lines = [];
+  const lines: Lines<Metadata> = [];
   const makeYFunc = () => {
     const amp1 = Math.random();
     const amp2 = Math.random();
@@ -181,13 +185,15 @@ const makeRandomCurves = (props: typeof propsBasic) => {
   };
 
   for (let l = 0; l < props.nL; l++) {
-    const line: Lines[number] = {
+    const color = colors[randomIndex(colors.length)];
+    const line: Lines<Metadata>[number] = {
       points: [],
       style: {
         opacity: Math.random() * props.opacityRange + props.opacityOffset,
-        color: colors[randomIndex(colors.length)],
+        color,
         strokeWidth: Math.random() * 1
-      }
+      },
+      metadata: { color }
     };
     const yfunc = makeYFunc();
     for (let i = 0; i < props.nX + 1; i++) {
@@ -198,8 +204,8 @@ const makeRandomCurves = (props: typeof propsBasic) => {
   return lines;
 };
 
-const tooltipHtmlCallback = (point: {x: number, y: number}) => {
-  return `X: ${point.x.toFixed(3)}, Y: ${point.y.toFixed(3)}`;
+const tooltipHtmlCallback = (point: {x: number, y: number, metadata?: Metadata}) => {
+  return `<div style="color: ${point.metadata?.color};">X: ${point.x.toFixed(3)}, Y: ${point.y.toFixed(3)}</div>`;
 };
 
 const curvesSparkLines = makeRandomCurves(propsBasic);
@@ -300,7 +306,7 @@ onMounted(async () => {
     .addZoom({ lockAxis: "x" })
     .appendTo(chartPointsAxesAndZoom.value!, scales);
 
-  new Chart()
+  new Chart<Metadata>()
     .addTraces(curvesTooltips)
     .addScatterPoints(pointsTooltips)
     .addTooltips(tooltipHtmlCallback)

--- a/src/layers/ScatterLayer.ts
+++ b/src/layers/ScatterLayer.ts
@@ -1,10 +1,10 @@
 import { LayerArgs, ScatterPoints } from "@/types";
 import { LayerType, OptionalLayer } from "./Layer";
 
-export class ScatterLayer extends OptionalLayer {
+export class ScatterLayer<Metadata> extends OptionalLayer {
   type = LayerType.Scatter;
 
-  constructor(public points: ScatterPoints) {
+  constructor(public points: ScatterPoints<Metadata>) {
     super();
   };
 

--- a/src/layers/TracesLayer.ts
+++ b/src/layers/TracesLayer.ts
@@ -91,13 +91,13 @@ const RDPAlgorithm = (linesSC: Point[][], epsilon: number) => {
   });
 };
 
-export class TracesLayer extends OptionalLayer {
+export class TracesLayer<Metadata> extends OptionalLayer {
   type = LayerType.Trace;
   private traces: D3Selection<SVGPathElement>[] = [];
   private lowResLinesSC: Point[][] = [];
   private getNewPoint: null | ((x: number, y: number, t: number) => Point) = null;
 
-  constructor(public linesDC: Lines, public options: TracesOptions) {
+  constructor(public linesDC: Lines<Metadata>, public options: TracesOptions) {
     super();
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import { LayerType, OptionalLayer } from "./layers/Layer";
 export type XY<T> = { x: T, y: T }
 
 export type Point = XY<number>
+export type PointWithMetadata<Metadata> = Point & { metadata?: Metadata }
 
 export type XYLabel = Partial<XY<string>>
 
@@ -56,24 +57,26 @@ export type ZoomExtents = Partial<XY<[number, number]>>
 export type Scales = XY<{ start: number, end: number }>
 export type PartialScales = Partial<XY<{ start?: number, end?: number }>>
 
-type LineConfig = {
+type LineConfig<Metadata> = {
   points: Point[],
   style: {
     color?: string,
     opacity?: number,
     strokeWidth?: number
     strokeDasharray?: string
-  }
+  },
+  metadata?: Metadata
 }
-export type Lines = LineConfig[]
+export type Lines<Metadata> = LineConfig<Metadata>[]
 
-type ScatterPointConfig = {
+type ScatterPointConfig<Metadata> = {
   x: number,
   y: number,
   style: {
     radius?: number,
     color?: string,
     opacity?: number
-  }
+  },
+  metadata?: Metadata
 }
-export type ScatterPoints = ScatterPointConfig[];
+export type ScatterPoints<Metadata> = ScatterPointConfig<Metadata>[];


### PR DESCRIPTION
we need a way for users to be able to pass in arbitrary metadata about a line/scatter point, for example in wodin if we do sensitivity run we need to see what value of beta produced the trace, this adds in an optional metadata field that the users can use in their tooltip callback to format tooltip based on the point, have added an example to the app demo