### PR TITLE
Mrc 6643 Add event type support for zoom and optimise zoom

### DIFF
--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -3,7 +3,7 @@ import { AxesLayer } from "./layers/AxesLayer";
 import { TracesLayer, TracesOptions } from "./layers/TracesLayer";
 import { ZoomLayer, ZoomOptions } from "./layers/ZoomLayer";
 import { TooltipHtmlCallback, TooltipsLayer } from "./layers/TooltipsLayer";
-import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, PartialScales, Point, Scales, ScatterPoints, XY, XYLabel } from "./types";
+import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, NumericZoomExtents, PartialScales, Point, Scales, ScatterPoints, XY, XYLabel } from "./types";
 import { LayerType, LifecycleHooks, OptionalLayer } from "./layers/Layer";
 import { GridLayer } from "./layers/GridLayer";
 import html2canvas from "html2canvas";
@@ -283,13 +283,17 @@ export class Chart<Metadata = any> {
       .attr("clip-path", `url(#${getHtmlId(LayerType.ClipPath)})`);
 
     const { x, y } = this.autoscaledMaxExtents;
+    const initialDomain: NumericZoomExtents = {
+      x: [initialExtents.x?.start ?? x.start, initialExtents.x?.end ?? x.end],
+      y: [initialExtents.y?.start ?? y.start, initialExtents.y?.end ?? y.end]
+    };
     const d3ScaleX = this.options.logScale.x ? d3.scaleLog : d3.scaleLinear;
     const scaleX = d3ScaleX()
-      .domain([initialExtents.x?.start ?? x.start, initialExtents.x?.end ?? x.end])
+      .domain(initialDomain.x)
       .range([ margin.left, width - margin.right ]);
     const d3ScaleY = this.options.logScale.y ? d3.scaleLog : d3.scaleLinear;
     const scaleY = d3ScaleY()
-      .domain([initialExtents.y?.start ?? y.start, initialExtents.y?.end ?? y.end])
+      .domain(initialDomain.y)
       .range([ height - margin.bottom, margin.top ]);
     
     const lineGen = d3.line<Point>()
@@ -327,7 +331,7 @@ export class Chart<Metadata = any> {
     // Clear any existing content in the element
     baseElement.childNodes.forEach(n => n.remove());
 
-    this.optionalLayers.forEach(l => l.draw(layerArgs));
+    this.optionalLayers.forEach(l => l.draw(layerArgs, initialDomain));
 
     baseElement.append(layerArgs.coreLayers[LayerType.Svg].node()!);
   };

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -3,7 +3,7 @@ import { AxesLayer } from "./layers/AxesLayer";
 import { TracesLayer, TracesOptions } from "./layers/TracesLayer";
 import { ZoomLayer, ZoomOptions } from "./layers/ZoomLayer";
 import { TooltipHtmlCallback, TooltipsLayer } from "./layers/TooltipsLayer";
-import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, NumericZoomExtents, PartialScales, Point, Scales, ScatterPoints, XY, XYLabel } from "./types";
+import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, ZoomExtents, PartialScales, Point, Scales, ScatterPoints, XY, XYLabel } from "./types";
 import { LayerType, LifecycleHooks, OptionalLayer } from "./layers/Layer";
 import { GridLayer } from "./layers/GridLayer";
 import html2canvas from "html2canvas";
@@ -283,7 +283,7 @@ export class Chart<Metadata = any> {
       .attr("clip-path", `url(#${getHtmlId(LayerType.ClipPath)})`);
 
     const { x, y } = this.autoscaledMaxExtents;
-    const initialDomain: NumericZoomExtents = {
+    const initialDomain: ZoomExtents = {
       x: [initialExtents.x?.start ?? x.start, initialExtents.x?.end ?? x.end],
       y: [initialExtents.y?.start ?? y.start, initialExtents.y?.end ?? y.end]
     };

--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -32,7 +32,7 @@
   <h1>Custom layers + custom lifecycle hooks</h1>
   <div class="chart" ref="chartCustom" id="chartCustom"></div>
 
-  <h1>Stress test: 800 traces</h1>
+  <h1>Stress test: 1000 traces</h1>
   <button @click="drawStressChart">Draw</button>
   <div class="chart" ref="chartStress" id="chartStress"></div>
 
@@ -114,7 +114,7 @@ const propsBasic = {
 
 const propsStress = {
   nX: 1000,
-  nL: 800,
+  nL: 1000,
   ampScaling: 1e6,
   freqRange: 0.1,
   freqOffset: 0.95,
@@ -342,7 +342,14 @@ onMounted(async () => {
     .addZoom()
     .addCustomLayer(new CustomLayer())
     .addCustomLifecycleHooks({
-      afterZoom() { console.log("triggered after zoom") }
+      beforeZoom(zoomExtents) {
+        if (zoomExtents.eventType !== "dblclick") return;
+        console.log("you double clicked!")
+      },
+      afterZoom(zoomExtents) {
+        if (!zoomExtents) return;
+        console.log("triggered after zoom")
+      }
     })
     .appendTo(chartCustom.value!);
 });

--- a/src/layers/Layer.ts
+++ b/src/layers/Layer.ts
@@ -1,4 +1,4 @@
-import { LayerArgs, NumericZoomExtents, ZoomExtents } from "@/types";
+import { LayerArgs, ZoomExtents, ZoomProperties } from "@/types";
 
 /*
   These are the various different types of layer types
@@ -25,16 +25,16 @@ export abstract class OptionalLayer<Properties = null> {
 
   constructor() {};
 
-  abstract draw(layerArgs: LayerArgs, currentExtents: NumericZoomExtents): void;
+  abstract draw(layerArgs: LayerArgs, currentExtents: ZoomExtents): void;
 
   // brush lifecycle hooks
   // note: brushEnd is the same as beforeZoom
   brushStart() {};
 
   // zoom lifecycle hooks
-  beforeZoom(_zoomExtents: ZoomExtents) {};
-  async zoom(_zoomExtents: ZoomExtents) {};
-  afterZoom(_zoomExtents: ZoomExtents | null) {};
+  beforeZoom(_zoomProperties: ZoomProperties) {};
+  async zoom(_zoomProperties: ZoomProperties) {};
+  afterZoom(_zoomProperties: ZoomProperties | null) {};
 };
 
 export type LifecycleHooks = Omit<OptionalLayer, "type" | "properties" | "draw">;

--- a/src/layers/Layer.ts
+++ b/src/layers/Layer.ts
@@ -1,4 +1,4 @@
-import { LayerArgs, ZoomExtents } from "@/types";
+import { LayerArgs, NumericZoomExtents, ZoomExtents } from "@/types";
 
 /*
   These are the various different types of layer types
@@ -25,7 +25,7 @@ export abstract class OptionalLayer<Properties = null> {
 
   constructor() {};
 
-  abstract draw(layerArgs: LayerArgs): void;
+  abstract draw(layerArgs: LayerArgs, currentExtents: NumericZoomExtents): void;
 
   // brush lifecycle hooks
   // note: brushEnd is the same as beforeZoom

--- a/src/layers/TracesLayer.ts
+++ b/src/layers/TracesLayer.ts
@@ -1,4 +1,4 @@
-import { D3Selection, LayerArgs, Lines, Point, ZoomExtents } from "@/types";
+import { D3Selection, LayerArgs, Lines, NumericZoomExtents, Point, ZoomExtents } from "@/types";
 import { LayerType, OptionalLayer } from "./Layer";
 
 export type TracesOptions = {
@@ -104,27 +104,54 @@ export class TracesLayer<Metadata> extends OptionalLayer {
   // d3 feeds the function we return from this function with t, which goes from
   // 0 to 1 with different jumps based on your ease, t = 0 is the start state of
   // your animation, t = 1 is the end state of your animation
-  private customTween = (index: number) => {
+  private customTween = (index: number, zoomExtents: NumericZoomExtents) => {
     const currLineSC = this.lowResLinesSC[index];
     return (t: number) => {
       const intermediateLineSC = currLineSC.map(({x, y}) => this.getNewPoint!(x, y, t));
-      return this.customLineGen(intermediateLineSC);
+      return this.customLineGen(intermediateLineSC, zoomExtents);
     };
   };
 
-  private customLineGen = (lineSC: Point[]) => {
-    let retStr = "M";
-    const { x, y } = lineSC[0];
-    retStr += x;
-    retStr += ",";
-    retStr += y;
+  private round = (num: number) => Math.floor(num * 10) / 10;
 
-    for (let i = 2; i < lineSC.length; i++) {
+  private customLineGen = (lineSC: Point[], zoomExtents: NumericZoomExtents) => {
+    let retStr = "";
+    const { x, y } = lineSC[0];
+    let wasLastPointInRange = zoomExtents.x[0] <= x && x <= zoomExtents.x[1]
+                           && zoomExtents.y[1] <= y && y <= zoomExtents.y[0];
+
+    for (let i = 0; i < lineSC.length; i++) {
       const { x, y } = lineSC[i];
-      retStr += "L";
-      retStr += x;
-      retStr += ",";
-      retStr += y;
+      const isPointInRange = zoomExtents.x[0] <= x && x <= zoomExtents.x[1]
+                          && zoomExtents.y[1] <= y && y <= zoomExtents.y[0];
+
+      // if last point in range we always want to add next point even if it
+      // isn't in range because we want the line to at least continue off the
+      // right edge of the svg
+      //
+      // if the last point wasn't in range but this point is, then we must be
+      // at the start of a new line segment so add the previous point too
+      // because we want the line to go off the left edge of the svg
+      if (wasLastPointInRange) {
+        retStr += retStr ? "L" : "M";
+        retStr += this.round(x);
+        retStr += ",";
+        retStr += this.round(y);
+      } else if (isPointInRange) {
+        // prev point will always exist, i.e. i will never be 0 in this branch
+        // because wasLastPointInRange will always match isCurrPointInRange for
+        // i = 0 so we have to fall into the previous branch
+        const { x: prevX, y: prevY } = lineSC[i - 1];
+        retStr += "M";
+        retStr += this.round(prevX);
+        retStr += ",";
+        retStr += this.round(prevY);
+        retStr += "L";
+        retStr += this.round(x);
+        retStr += ",";
+        retStr += this.round(y);
+      }
+      wasLastPointInRange = isPointInRange;
     }
 
     return retStr;
@@ -142,11 +169,16 @@ export class TracesLayer<Metadata> extends OptionalLayer {
     }
   };
 
-  draw = (layerArgs: LayerArgs) => {
+  draw = (layerArgs: LayerArgs, currentExtentsDC: NumericZoomExtents) => {
     this.updateLowResLinesSC(layerArgs);
+    const { x: scaleX, y: scaleY } = layerArgs.scaleConfig.linearScales;
+    const currentExtentsSC: NumericZoomExtents = {
+      x: [scaleX(currentExtentsDC.x[0]), scaleX(currentExtentsDC.x[1])],
+      y: [scaleY(currentExtentsDC.y[0]), scaleY(currentExtentsDC.y[1])],
+    };
 
     this.traces = this.linesDC.map((l, index) => {
-      const linePathSC = this.customLineGen(this.lowResLinesSC[index]);
+      const linePathSC = this.customLineGen(this.lowResLinesSC[index], currentExtentsSC);
       return layerArgs.coreLayers[LayerType.BaseLayer].append("path")
         .attr("id", `${layerArgs.getHtmlId(LayerType.Trace)}-${index}`)
         .attr("pointer-events", "none")
@@ -158,7 +190,7 @@ export class TracesLayer<Metadata> extends OptionalLayer {
         .attr("d", linePathSC);
     });
 
-    this.beforeZoom = (zoomExtentsDC: ZoomExtents) => {
+    this.beforeZoom = (zoomExtentsDC: NumericZoomExtents) => {
       const { x: scaleX, y: scaleY } = layerArgs.scaleConfig.linearScales;
 
       // we have to convert the extents to SC from DC to find out what pixel
@@ -195,14 +227,20 @@ export class TracesLayer<Metadata> extends OptionalLayer {
     };
 
     // the zoom layer updates scaleX and scaleY which change our customLineGen function
-    this.zoom = async () => {
+    this.zoom = async zoomExtentsDC => {
+      const { x: scaleX, y: scaleY } = layerArgs.scaleConfig.linearScales;
+      const zoomExtentsSC: NumericZoomExtents = {
+        x: [scaleX(zoomExtentsDC.x[0]), scaleX(zoomExtentsDC.x[1])],
+        y: [scaleY(zoomExtentsDC.y[0]), scaleY(zoomExtentsDC.y[1])],
+      };
+
       const promises: Promise<void>[] = [];
       for (let i = 0; i < this.linesDC.length; i++) {
         const promise = this.traces[i]
           .transition()
           .duration(layerArgs.globals.animationDuration)
           // we do a custom animation because it is faster than d3's default
-          .attrTween("d", () => this.customTween(i))
+          .attrTween("d", () => this.customTween(i, zoomExtentsSC))
           .end();
         promises.push(promise);
       };
@@ -212,7 +250,7 @@ export class TracesLayer<Metadata> extends OptionalLayer {
       // without the user knowing
       this.updateLowResLinesSC(layerArgs);
       this.traces.forEach((t, index) => {
-        t.attr("d", this.customLineGen(this.lowResLinesSC[index]))
+        t.attr("d", this.customLineGen(this.lowResLinesSC[index], zoomExtentsSC))
       });
     };
   };

--- a/src/skadi-chart.ts
+++ b/src/skadi-chart.ts
@@ -1,5 +1,5 @@
 import { Chart } from "./Chart";
-import { Lines, Scales, ZoomExtents, LayerArgs, ScatterPoints } from "./types";
+import { Lines, Scales, ZoomExtents, ZoomProperties, LayerArgs, ScatterPoints } from "./types";
 import { OptionalLayer, LayerType } from "./layers/Layer";
 export { Chart, OptionalLayer, LayerType };
-export type { Lines, Scales, ZoomExtents, LayerArgs, ScatterPoints }
+export type { Lines, Scales, ZoomExtents, ZoomProperties, LayerArgs, ScatterPoints }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,8 @@ export type LayerArgs = {
   chartOptions: ChartOptions
 };
 
-export type ZoomExtents = Partial<XY<[number, number]>>
+export type NumericZoomExtents = XY<[number, number]>
+export type ZoomExtents = NumericZoomExtents & { eventType: "brush" | "dblclick" }
 export type Scales = XY<{ start: number, end: number }>
 export type PartialScales = Partial<XY<{ start?: number, end?: number }>>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,8 +53,8 @@ export type LayerArgs = {
   chartOptions: ChartOptions
 };
 
-export type NumericZoomExtents = XY<[number, number]>
-export type ZoomExtents = NumericZoomExtents & { eventType: "brush" | "dblclick" }
+export type ZoomExtents = XY<[number, number]>
+export type ZoomProperties = ZoomExtents & { eventType: "brush" | "dblclick" }
 export type Scales = XY<{ start: number, end: number }>
 export type PartialScales = Partial<XY<{ start?: number, end?: number }>>
 


### PR DESCRIPTION
This adds two main things, things:

1. zoom event type to zoom extents, in wodin it is useful to know the type of event that caused the zoom namely `brush` being equivalent to zooming in and `dblclick` being equivalent to zooming out
2. we have further optimised zoom to only draw the line in the svg clip path, there was a reason for this optimisation, before we were adding the entire line to the `<path>` element's `d` attribute but this was causing problems as you keep zooming in more and more, because the numbers in the `d` attribute kept getting larger and larger as we kept zooming in, this caused lag when you zoomed in too much, this optimisation means that only the path visible in the svg is added to the `d` attribute