### PR TITLE
Only allow zooming on non-categorical axes

### DIFF
--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -314,6 +314,7 @@ const drawChartCategoricalYAxis = () => {
   new Chart({ logScale: { x: logScaleX.value, y: logScaleY.value }})
     .addAxes({ x: "Time", y: "Category" })
     .addTraces(curvesCategoricalYAxis)
+    .addZoom({ lockAxis: "y" })
     .appendTo(chartCategoricalYAxis.value!, {}, {}, { y: categoricalYAxis });
 };
 
@@ -321,6 +322,7 @@ const drawChartCategoricalXAxis = () => {
   new Chart({ logScale: { x: logScaleX.value, y: logScaleY.value }})
     .addAxes({ x: "Category", y: "Value" })
     .addTraces(curvesCategoricalXAxis)
+    .addZoom({ lockAxis: "x" })
     .appendTo(chartCategoricalXAxis.value!, {}, {}, { x: categoricalXAxis });
 };
 

--- a/src/layers/ZoomLayer.ts
+++ b/src/layers/ZoomLayer.ts
@@ -114,6 +114,16 @@ export class ZoomLayer extends OptionalLayer {
   };
 
   draw = (layerArgs: LayerArgs) => {
+    Object.entries(layerArgs.scaleConfig.categoricalScales).forEach(([axis]) => {
+      if (this.options.lockAxis !== axis) {
+        console.warn(
+          `You have tried to use zoom with a categorical scale (\`d3.scaleBand\`) but this is not supported. `
+          + `Zoom is only available for numerical scales (\`d3.scaleLinear\` or \`d3.scaleLog\`). `
+          + `Lock the categorical axis ${axis} explicitly using the \`lockAxis\` option to enable zooming on the numerical axis only.`
+        );
+      }
+    });
+
     const { width, height, margin } = layerArgs.bounds;
     const svg = layerArgs.coreLayers[LayerType.Svg];
     


### PR DESCRIPTION
With this change, zooming works fully for traces on categorical axes, and for scatter points on categorical axes.