### PR TITLE
Categorical axis for scatter layers

### DIFF
--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -170,6 +170,18 @@ const makeRandomPoints = (props: typeof pointPropsBasic) => {
   return points;
 };
 
+const makeRandomPointsForCategoricalAxis = (domain: string[], axis: "x" | "y"): ScatterPoints<Metadata> => {
+  return makeRandomPoints(pointPropsBasic).map((point, index) => {
+    const band = domain[index % domain.length];
+    const color = colors[index % domain.length];
+    return {
+      ...point,
+      bands: { [axis]: band },
+      style: { ...point.style, color }
+    }
+  });
+};
+
 const makeRandomCurves = (props: typeof propsBasic) => {
   const xPoints = Array.from({length: props.nX + 1}, (_, i) => i / props.nX);
   const lines: Lines<Metadata> = [];
@@ -258,8 +270,10 @@ const curvesTooltips = makeRandomCurves(propsBasic);
 const pointsTooltips = makeRandomPoints(pointPropsTooltips);
 const curvesResponsive = makeRandomCurves(propsBasic);
 const curvesCustom = makeRandomCurves(propsBasic);
-const curvesCategoricalYAxis = makeRandomCurvesForCategoricalAxis(categoricalYAxis, "y");
 const curvesCategoricalXAxis = makeRandomCurvesForCategoricalAxis(categoricalXAxis, "x");
+const curvesCategoricalYAxis = makeRandomCurvesForCategoricalAxis(categoricalYAxis, "y");
+const pointsCategoricalXAxis = makeRandomPointsForCategoricalAxis(categoricalXAxis, "x");
+const pointsCategoricalYAxis = makeRandomPointsForCategoricalAxis(categoricalYAxis, "y");
 
 const scales: Scales = { x: {start: 0, end: 1}, y: {start: -3e6, end: 3e6} };
 
@@ -311,6 +325,7 @@ const drawChartCategoricalYAxis = () => {
   new Chart({ logScale: { x: categoricalYAxisLogScaleX.value, y: categoricalYAxisLogScaleY.value }})
     .addAxes({ x: "Time", y: "Category" })
     .addTraces(curvesCategoricalYAxis)
+    .addScatterPoints(pointsCategoricalYAxis)
     .appendTo(chartCategoricalYAxis.value!, scales, {}, { y: categoricalYAxis });
 };
 
@@ -325,6 +340,7 @@ const drawChartCategoricalXAxis = () => {
   new Chart({ logScale: { x: categoricalXAxisLogScaleX.value, y: categoricalXAxisLogScaleY.value }})
     .addAxes({ x: "Category", y: "Value" })
     .addTraces(curvesCategoricalXAxis)
+    .addScatterPoints(pointsCategoricalXAxis)
     .appendTo(chartCategoricalXAxis.value!, scales, {}, { x: categoricalXAxis });
 };
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,13 @@
+import { LayerArgs, ScaleNumeric, XY } from "./types";
+
+// Given a bands config for a line or point, return the numerical scales to use for x and y.
+export const numScales = (bands: Partial<XY<string>> | undefined, layerArgs: LayerArgs): XY<ScaleNumeric> => {
+  const { x: numericalScaleX, y: numericalScaleY } = layerArgs.scaleConfig.linearScales;
+  const { x: categoricalScaleX, y: categoricalScaleY } = layerArgs.scaleConfig.categoricalScales;
+  const { x: bandX, y: bandY } = bands || {};
+
+  return {
+    x: bandX && categoricalScaleX ? categoricalScaleX.bands[bandX] : numericalScaleX,
+    y: bandY && categoricalScaleY ? categoricalScaleY.bands[bandY] : numericalScaleY,
+  }
+}

--- a/src/layers/ScatterLayer.ts
+++ b/src/layers/ScatterLayer.ts
@@ -1,5 +1,6 @@
 import { LayerArgs, ScatterPoints } from "@/types";
 import { LayerType, OptionalLayer } from "./Layer";
+import { numScales } from "@/helpers";
 
 export class ScatterLayer<Metadata> extends OptionalLayer {
   type = LayerType.Scatter;
@@ -13,14 +14,16 @@ export class ScatterLayer<Metadata> extends OptionalLayer {
     const baseLayer = layerArgs.coreLayers[LayerType.BaseLayer];
     const { animationDuration } = layerArgs.globals;
     const { getHtmlId } = layerArgs;
-  
+
     const scatter = baseLayer.append("g");
     const scatterPoints = this.points.map((p, index) => {
+      const scales = numScales(p.bands, layerArgs);
+
       return scatter.append("circle")
         .attr("id", `${getHtmlId(LayerType.Scatter)}-${index}`)
         .attr("pointer-events", "none")
-        .attr("cx", scaleX(p.x))
-        .attr("cy", scaleY(p.y))
+        .attr("cx", scales.x(p.x))
+        .attr("cy", scales.y(p.y))
         .attr("r", p.style?.radius || "0.2%")
         .attr("fill", p.style?.color || "black")
         .style("opacity", p.style?.opacity || 1)

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ type ScatterPointConfig<Metadata> = {
   x: number,
   y: number,
   style: ScatterPointStyle,
-  metadata?: Metadata
+  metadata?: Metadata,
+  bands?: Partial<XY<string>>
 }
 export type ScatterPoints<Metadata> = ScatterPointConfig<Metadata>[];


### PR DESCRIPTION
Following on from https://github.com/mrc-ide/skadi-chart/pull/44: scatter points now know how to arrange themselves onto categorical axes.

To that end, I extract `lineScales` from the TracesLayer to become a shared `numScales` function to be used by that layer and ScatterLayer (and future layers).

This PR deliberately does not implement zooming or tooltips, leaving these to follow-up PRs.

Things that should, in fact, work:

* categorical axis on y or x
* any numerical axis (including those within the 'bands') may be logarithmic