### PR TITLE
Add debounced resize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reside-ic/skadi-chart",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reside-ic/skadi-chart",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "dependencies": {
         "d3-axis": "^3.0.0",
         "d3-brush": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reside-ic/skadi-chart",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reside-ic/skadi-chart",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "dependencies": {
         "d3-axis": "^3.0.0",
         "d3-brush": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reside-ic/skadi-chart",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "type": "module",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reside-ic/skadi-chart",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "type": "module",
   "files": [
     "dist"

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -8,7 +8,7 @@ import { LayerType, LifecycleHooks, OptionalLayer } from "./layers/Layer";
 import { GridLayer } from "./layers/GridLayer";
 import html2canvas from "html2canvas";
 import { ScatterLayer } from "./layers/ScatterLayer";
-import { getXYMinMax } from "./helpers";
+import { debounce, DebounceConfig, getXYMinMax } from "./helpers";
 import { AreaLayer } from "./layers/AreaLayer";
 
 // used for holding custom lifecycle hooks only - layer has no visual effect
@@ -320,11 +320,11 @@ export class Chart<Metadata = any> {
  
     const svg = d3.create("svg")
       .attr("id", getHtmlId(LayerType.Svg))
-      .attr("width", "100%")
-      .attr("height", "100%")
+      .attr("width", width)
+      .attr("height", height)
       .attr("viewBox", `0 0 ${width} ${height}`)
       .attr("style", "overflow: visible;")
-      .attr("preserveAspectRatio", "xMinYMin") as any as D3Selection<SVGSVGElement>;
+      .attr("preserveAspectRatio", "none") as any as D3Selection<SVGSVGElement>;
 
     const { clipPath, clipPathBounds } = this.appendClipPath(bounds, clipPathBoundsOptions, svg, getHtmlId);
 
@@ -423,10 +423,15 @@ export class Chart<Metadata = any> {
     drawWithBounds(width, height);
 
     if (this.isResponsive) {
+      let debounceConfig: DebounceConfig = {
+        timeout: undefined,
+        time: 50
+      };
+
       // watch for changes in baseElement
       const resizeObserver = new ResizeObserver(entries => {
         const { blockSize: height, inlineSize: width } = entries[0].borderBoxSize[0];
-        drawWithBounds(width, height);
+        debounce(debounceConfig, () => drawWithBounds(width, height));
       });
       resizeObserver.observe(baseElement);
 
@@ -436,7 +441,7 @@ export class Chart<Metadata = any> {
       window.addEventListener("resize", e => {
         if (!e.view) return;
         const { innerHeight: height, innerWidth: width } = e.view;
-        drawWithBounds(width, height);
+        debounce(debounceConfig, () => drawWithBounds(width, height));
       });
     }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -118,6 +118,8 @@ export type DebounceConfig = {
   time: number
 }
 
+// DebounceConfig in the first arg, we can let multiple debounced
+// calls share a timeout
 export const debounce = (cfg: DebounceConfig, callback: () => any) => {
   clearTimeout(cfg.timeout);
   cfg.timeout = setTimeout(() => {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -112,3 +112,15 @@ export const drawLine = (
     .attr("y2", coordsSC.y.end)
     .style("stroke", color).style("stroke-width", 0.5);
 }
+
+export type DebounceConfig = {
+  timeout: NodeJS.Timeout | undefined,
+  time: number
+}
+
+export const debounce = (cfg: DebounceConfig, callback: () => any) => {
+  clearTimeout(cfg.timeout);
+  cfg.timeout = setTimeout(() => {
+    callback();
+  }, cfg.time);
+};


### PR DESCRIPTION
have left some useful comments, this was required because in wodin graphs with many hundreds of traces need to be responsive, that is not something we support fully until this pr, it is computationally intense to redraw the entire graph everytime the container holding it resizes as there are many resize events every second, so we debounce this and it works much better