### PR TITLE
Let user configure whether zero-line is drawn, per axis

### DIFF
--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -3,7 +3,7 @@ import { AxesLayer } from "./layers/AxesLayer";
 import { TracesLayer, TracesOptions } from "./layers/TracesLayer";
 import { ZoomLayer, ZoomOptions } from "./layers/ZoomLayer";
 import { TooltipHtmlCallback, TooltipsLayer } from "./layers/TooltipsLayer";
-import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, ZoomExtents, PartialScales, Point, Scales, ScatterPoints, XY, XYLabel, ScaleNumeric, AxisType, CategoricalScaleConfig, ClipPathBounds, TickConfig } from "./types";
+import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, ZoomExtents, PartialScales, Point, Scales, ScatterPoints, XY, ScaleNumeric, AxisType, CategoricalScaleConfig, ClipPathBounds, TickConfig } from "./types";
 import { LayerType, LifecycleHooks, OptionalLayer } from "./layers/Layer";
 import { GridLayer, GridOptions } from "./layers/GridLayer";
 import html2canvas from "html2canvas";
@@ -86,15 +86,28 @@ export class Chart<Metadata = any> {
     return this;
   };
 
-  addAxes = (labels: XYLabel = {}, labelPositions?: Partial<XY<number>>) => {
+  addAxes = (
+    labels: Partial<XY<string>> = {},
+    labelPositions?: Partial<XY<number>>,
+    includeZeroLine?: Partial<XY<boolean>>,
+  ) => {
     if (labels.x) this.defaultMargin.bottom = 80;
     if (labels.y) this.defaultMargin.left = 90;
-    this.optionalLayers.push(new AxesLayer(
-      labels || {},
-      {
-        x: labelPositions?.x ?? 1/3,
-        y: labelPositions?.y ?? 1/3,
-      }));
+    if ((includeZeroLine?.x && this.options.logScale.x) || (includeZeroLine?.y && this.options.logScale.y)) {
+      console.warn("You have requested a zero line on a log scale axis, which is not possible. The zero line will not be shown.");
+    }
+    this.optionalLayers.push(new AxesLayer({
+      x: {
+        label: labels.x,
+        labelPosition: labelPositions?.x ?? 1 / 3,
+        includeZeroLine: includeZeroLine?.x ?? !this.options.logScale.x,
+      },
+      y: {
+        label: labels.y,
+        labelPosition: labelPositions?.y ?? 1 / 3,
+        includeZeroLine: includeZeroLine?.y ?? !this.options.logScale.y,
+      },
+    }));
     return this;
   };
 

--- a/src/layers/AxesLayer.ts
+++ b/src/layers/AxesLayer.ts
@@ -1,9 +1,15 @@
 import * as d3 from "@/d3";
 import { LayerType, OptionalLayer } from "./Layer";
-import { AxisType, D3Selection, LayerArgs, ScaleNumeric, XY, XYLabel } from "@/types";
+import { AxisType, D3Selection, LayerArgs, ScaleNumeric, XY } from "@/types";
 import { drawLine } from "@/helpers";
 
 declare const MathJax: any;
+
+export type AxisConfig = {
+  label?: string,
+  labelPosition: number,
+  includeZeroLine: boolean,
+}
 
 type AxisElements = ({
   layer: D3Selection<SVGGElement>,
@@ -18,7 +24,7 @@ type AxisElements = ({
 export class AxesLayer extends OptionalLayer {
   type = LayerType.Axes;
 
-  constructor(public labels: XYLabel, public labelPositions: XY<number>) {
+  constructor(public options: XY<AxisConfig>) {
     super();
   };
 
@@ -27,21 +33,21 @@ export class AxesLayer extends OptionalLayer {
     const { getHtmlId } = layerArgs;
     const numericalScale = layerArgs.scaleConfig.numericalScales[axis];
 
-    if (this.labels[axis]) {
+    if (this.options[axis].label) {
       const label = layerArgs.coreLayers[LayerType.Svg].append("text")
         .attr("id", `label${axis}-${getHtmlId(LayerType.Axes)}`)
         .style("font-size", "1.2rem")
         .attr("text-anchor", "middle")
-        .text(this.labels[axis])
+        .text(this.options[axis].label)
       if (axis === "y") {
         const usableHeight = height - margin.top - margin.bottom;
         label.attr("x", - usableHeight / 2 - margin.top)
-          .attr("y", margin.left * this.labelPositions.y)
+          .attr("y", margin.left * this.options[axis].labelPosition)
           .attr("transform", "rotate(-90)")
       } else {
         const usableWidth = width - margin.left - margin.right;
         label.attr("x", usableWidth / 2 + margin.left)
-          .attr("y", height - margin.bottom * this.labelPositions.x)
+          .attr("y", height - margin.bottom * this.options[axis].labelPosition)
       }
     }
 
@@ -110,7 +116,7 @@ export class AxesLayer extends OptionalLayer {
     const bandwidth = categoricalScale.bandwidth();
 
     const axisMargin = axis === "x" ? margin.bottom : margin.left;
-    const defaultTickPadding = axisMargin * (1 - this.labelPositions?.[axis]) / 3;
+    const defaultTickPadding = axisMargin * (1 - this.options[axis].labelPosition) / 3;
     const categoricalAxis = axisConstructor(categoricalScale)
       .tickSize(tickSize ?? 0)
       .tickPadding(tickPadding ?? defaultTickPadding);
@@ -202,8 +208,8 @@ export class AxesLayer extends OptionalLayer {
 
     let axisLines: D3Selection<SVGLineElement>[] = [];
     // Draw a line at [axis]=0 if this is within scale range
-    const [minDC, maxDC] = scale.domain().sort();
-    if (!layerArgs.chartOptions.logScale[axis] && minDC <= 0 && maxDC >= 0) {
+    const [minDC, maxDC] = [...scale.domain()].sort();
+    if (this.options[axis].includeZeroLine && minDC <= 0 && maxDC >= 0) {
       axisLines = this.drawLinePerpendicularToAxis(axis, scale(0), layerArgs, "darkgrey");
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,8 +10,6 @@ export type PointWithMetadata<Metadata> = Point & {
   bands?: Partial<XY<string>>
 }
 
-export type XYLabel = Partial<XY<string>>
-
 /*
   These are bounds of the svg element
 */


### PR DESCRIPTION
There's a long story why I want this feature:

Vaxviz uses its own log scale (inherent to the data files VIMC give us, i.e. they contain the histogram bins for already-logged datapoints), and not d3's log scale via skadi-chart. So, when it passes data points to skadi-chart, it tells skadi-chart to use linear scales. At the moment, this results in an axis-line being drawn at what skadi-chart _thinks_ is x=0, but when log scale is enabled in vaxviz 'x=0' really means 'x=10^0'. (And actually, because we're using an 'impact ratio' that expresses things in terms of '1000s of things averted per vaccination', x=10^0 actually means x=1000*10^0.) This all means that there is no important significance at x=0, so there is no need to draw an axis line there.

Unless the user overrides it by using the `includeZeroLine` config property, skadi-chart will continue to have the same default behaviour of drawing a line at axis = 0 (when relevant).