### PR TITLE
Don't draw gridlines across band inner padding (gaps between bands)

### DIFF
--- a/src/demo/App.vue
+++ b/src/demo/App.vue
@@ -480,6 +480,8 @@ const drawChartBothCategoricalAxes = () => {
   })
     .addAxes({ x: "Category", y: "Category" }, { y: 0.2 }, drawZeroLinesOnBothCategoricalAxesChart.value)
     .addScatterPoints(pointsBothCategoricalAxes)
+    .addGridLines()
+    .addTooltips(tooltipHtmlCallback)
     .appendTo(
       chartBothCategoricalAxes.value!,
       { ...scales, x: { start: -1, end: scales.x.end } },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -60,6 +60,15 @@ export const numScales = (bands: Partial<XY<string>> | undefined, layerArgs: Lay
   }
 }
 
+export const axes = ["x", "y"] as const satisfies [AxisType, AxisType];
+
+// Given an axis ('x' or 'y'), return all the numerical scales for that axis.
+export const numScalesForAxis = (axis: AxisType, layerArgs: LayerArgs): ScaleNumeric[] => {
+  const { numericalScales, categoricalScales } = layerArgs.scaleConfig;
+  const bandScales = categoricalScales[axis]?.bands;
+  return bandScales ? Object.values(bandScales) : [numericalScales[axis]];
+}
+
 export const getXYMinMax = (points: Point[]) => {
   const scales: Scales = {
     x: { start: Infinity, end: -Infinity },

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -232,7 +232,7 @@ test("categorical y axis", async ({ page }) => {
     .expectAxes({ x: 1, y: 6 }) // 6 = 5 numerical axes within each band, plus 1 main categorical axis
     .expectTooltip()
     .expectLabels({ x: "Time", y: "Category" })
-    .expectGridlines({ x: 1, y: 0 })
+    .expectGridlines({ x: 5, y: 0 })
     .expectZoom()
     .end();
 });
@@ -246,6 +246,15 @@ test("categorical x axis", async ({ page }) => {
     .expectGridlines({ x: 2, y: 0 })
     .expectLabels({ x: "Category", y: "Value" })
     .expectZoom()
+    .end();
+});
+
+test("chart with both categorical x and y axes", async ({ page }) => {
+  await new SkadiChartTest(page, "chartBothCategoricalAxes")
+    .expectNPoints(1000)
+    .expectAxes({ x: 3, y: 6 })
+    .expectGridlines({ x: 10, y: 10 })
+    .expectLabels({ x: "Category", y: "Category" })
     .end();
 });
 


### PR DESCRIPTION
When gridlines are enabled for both axes, and both axes have categorical scales with band inner padding, then the gridlines should not cross the padding:

<img width="1011" height="548" alt="image" src="https://github.com/user-attachments/assets/4e352077-4abe-4751-8411-7e2dff7a28a7" />

To do this, I now define a 'gridline set' to refer to the set of gridliens in a given direction for a given combo of numerical scales. Those numerical scales can either be the normal numerical scale, or one that belongs to a particular band.

I de-duplicated some code in GridLayer that was written once per x and y, so now it refers instead to 'axis A' and 'axis B'.
