### PR TITLE
Refactor AxesLayer function 'drawLinePerpendicularToAxis'

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -60,6 +60,13 @@ export const numScales = (bands: Partial<XY<string>> | undefined, layerArgs: Lay
   }
 }
 
+// Given an axis ('x' or 'y'), return all the numerical scales for that axis.
+export const numScalesForAxis = (axis: AxisType, layerArgs: LayerArgs): ScaleNumeric[] => {
+  const { numericalScales, categoricalScales } = layerArgs.scaleConfig;
+  const bandScales = categoricalScales[axis]?.bands;
+  return bandScales ? Object.values(bandScales) : [numericalScales[axis]];
+}
+
 export const getXYMinMax = (points: Point[]) => {
   const scales: Scales = {
     x: { start: Infinity, end: -Infinity },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -107,19 +107,6 @@ export const mapScales = <T>(
   return [mappedMainScales, mappedCategoricalScales]
 }
 
-export const drawLine = (
-  baseLayer: D3Selection<SVGGElement>,
-  coordsSC: XY<{start: number, end: number}>,
-  color: string,
-) => {
-  return baseLayer.append("g").append("line")
-    .attr("x1", coordsSC.x.start)
-    .attr("x2", coordsSC.x.end)
-    .attr("y1", coordsSC.y.start)
-    .attr("y2", coordsSC.y.end)
-    .style("stroke", color).style("stroke-width", 0.5);
-}
-
 export type DebounceConfig = {
   timeout: NodeJS.Timeout | undefined,
   time: number

--- a/src/layers/AxesLayer.ts
+++ b/src/layers/AxesLayer.ts
@@ -233,12 +233,12 @@ export class AxesLayer extends OptionalLayer {
     const otherAxisScales = numScalesForAxis(otherAxis, layerArgs);
 
     const lineParts = otherAxisScales.map(otherAxisScale => {
-      const lineCoordsSC = {
-        [axis]: { start: positionSC, end: positionSC },
-        [otherAxis]: { start: otherAxisScale.range()[0], end: otherAxisScale.range()[1] },
-      } as XY<{start: number, end: number}>;
-
-      return drawLine(baseLayer, lineCoordsSC, color);
+      return baseLayer.append("g").append("line")
+        .attr(`${axis}1`, positionSC)
+        .attr(`${axis}2`, positionSC)
+        .attr(`${otherAxis}1`, otherAxisScale.range()[0])
+        .attr(`${otherAxis}2`, otherAxisScale.range()[1])
+        .style("stroke", color).style("stroke-width", 0.5);
     })
     return lineParts.filter(line => line !== undefined);
   }

--- a/src/layers/AxesLayer.ts
+++ b/src/layers/AxesLayer.ts
@@ -1,7 +1,7 @@
 import * as d3 from "@/d3";
 import { LayerType, OptionalLayer } from "./Layer";
 import { AxisType, D3Selection, LayerArgs, ScaleNumeric, XY } from "@/types";
-import { drawLine } from "@/helpers";
+import { drawLine, numScalesForAxis } from "@/helpers";
 
 declare const MathJax: any;
 
@@ -218,6 +218,10 @@ export class AxesLayer extends OptionalLayer {
   }
 
   // Draws a line perpendicular to the specified axis at the given position in scale coordinates.
+  // If the other axis is not a categorical axis, we simply draw one line and return.
+  // If the other axis is categorical, we draw a line for each category band of the other axis,
+  // to prevent lines cutting through inter-band padding (i.e. we draw 'one' interrupted 'line'
+  // out of multiple shorter lines with gaps for padding as required by the other axis).
   private drawLinePerpendicularToAxis = (
     axis: AxisType,
     positionSC: number,
@@ -225,39 +229,16 @@ export class AxesLayer extends OptionalLayer {
     color: string = "black",
   ): D3Selection<SVGLineElement>[] => {
     const baseLayer = layerArgs.coreLayers[LayerType.BaseLayer];
-    const { height, width, margin } = layerArgs.bounds;
     const otherAxis = axis === "x" ? "y" : "x";
-    const otherAxisCategoricalScale = layerArgs.scaleConfig.categoricalScales[otherAxis]?.main;
+    const otherAxisScales = numScalesForAxis(otherAxis, layerArgs);
 
-    // If the other axis is not a categorical axis, simply draw one line and return.
-    if (!otherAxisCategoricalScale) {
-      let lineCoordsSC = { [axis]: { start: positionSC, end: positionSC } };
-      if (axis === "x") {
-        lineCoordsSC.y = { start: margin.top, end: height - margin.bottom };
-      } else {
-        lineCoordsSC.x = { start: margin.left, end: width - margin.right };
-      }
-      return [drawLine(baseLayer, lineCoordsSC as XY<{start: number, end: number}>, color)];
-    }
-
-    // If the other axis is categorical, draw a line for each category band of the other axis,
-    // to prevent lines cutting through inter-band padding (i.e. we draw 'one' interrupted 'line'
-    // out of multiple shorter lines with gaps for padding as required by the other axis).
-    const otherAxisBandWidth = otherAxisCategoricalScale.bandwidth();
-    const otherAxisPositionSC = otherAxis === "x" ? height - margin.bottom : margin.left;
-    const lineParts = otherAxisCategoricalScale.domain().map(category => {
-      const otherAxisBandStart = otherAxisCategoricalScale(category);
-      if (otherAxisBandStart === undefined) return;
-
-      // Don't draw the line if it would be drawn on top of the other-axis line itself
-      if (positionSC === otherAxisPositionSC) return;
-
+    const lineParts = otherAxisScales.map(otherAxisScale => {
       const lineCoordsSC = {
         [axis]: { start: positionSC, end: positionSC },
-        [otherAxis]: { start: otherAxisBandStart, end: otherAxisBandStart + otherAxisBandWidth },
-      };
+        [otherAxis]: { start: otherAxisScale.range()[0], end: otherAxisScale.range()[1] },
+      } as XY<{start: number, end: number}>;
 
-      return drawLine(baseLayer, lineCoordsSC as XY<{start: number, end: number}>, color);
+      return drawLine(baseLayer, lineCoordsSC, color);
     })
     return lineParts.filter(line => line !== undefined);
   }


### PR DESCRIPTION
I spotted a much shorter way to write this function.

Instead of doing conditional branches based on checking whether there is a categorical axis involved or not, we can iterate over a list of numerical scales (which in the case of no categorical axis, will just have a length of 1).

The reason this is possible is because I realised that numerical scales can tell us their start and end in SC via `scale.range()`, without any need to query the categorical scale for the band start and band width information.

NB I removed the logic about 'Don't draw the line if it would be drawn on top of the other-axis line itself', because this was incorrect anyway: it assumed two things that may not be true, namely (1) that the other-axis axis line exists*, and (2) that it lines up with the edge of the chart, whereas in fact it's drawn at axis=0, which is not always on the edge.

*this depends on whether the evaluation of line 213 is true:

```ts
if (this.options[axis].includeZeroLine && minDC <= 0 && maxDC >= 0)
```