### PR TITLE
Mrc 6888 Remove debounce and add iterator for all points

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,3 +282,12 @@ any functions that will remove layers after the chart is appended to the DOM.
 The pattern we use for reactivity outside of the scope of lifecycle hooks is to recreate the
 chart from scratch. The `appendTo` function will remove anything inside the chart `div` and
 append the new `Chart` into it. To see examples of reactivity see [here](./src/demo/App.vue).
+
+### Note for performance regarding reactivity
+
+Proxy objects can degrade performance. Frameworks like Vue proxy objects for reactivity or
+you may be manually creating them. Skadi chart does not modify arguments passed into it
+(i.e. does not use setters for any argument) however, Skadi chart does use getters many times
+as different layers scan your arguments, particularly your data. If you are experiencing
+performance issues, make sure to remove the proxy or remove getters. For example, in Vue
+you can use `markRaw` or `shallowRef` to prevent Vue from creating deep proxy objects.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reside-ic/skadi-chart",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reside-ic/skadi-chart",
-      "version": "1.1.13",
+      "version": "1.1.14",
       "dependencies": {
         "d3-axis": "^3.0.0",
         "d3-brush": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reside-ic/skadi-chart",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "type": "module",
   "files": [
     "dist"

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -3,12 +3,12 @@ import { AxesLayer } from "./layers/AxesLayer";
 import { TracesLayer, TracesOptions } from "./layers/TracesLayer";
 import { ZoomLayer, ZoomOptions } from "./layers/ZoomLayer";
 import { TooltipHtmlCallback, TooltipsLayer } from "./layers/TooltipsLayer";
-import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, ZoomExtents, PartialScales, Point, Scales, ScatterPoints, XY, ScaleNumeric, AxisType, CategoricalScaleConfig, ClipPathBounds, TickConfig } from "./types";
+import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, ZoomExtents, PartialScales, Scales, ScatterPoints, XY, ScaleNumeric, AxisType, CategoricalScaleConfig, ClipPathBounds, TickConfig } from "./types";
 import { LayerType, LifecycleHooks, OptionalLayer } from "./layers/Layer";
 import { GridLayer, GridOptions } from "./layers/GridLayer";
 import html2canvas from "html2canvas";
 import { ScatterLayer } from "./layers/ScatterLayer";
-import { debounce, DebounceConfig, getXYMinMax } from "./helpers";
+import { getXYMinMax } from "./helpers";
 import { AreaLayer } from "./layers/AreaLayer";
 
 // used for holding custom lifecycle hooks only - layer has no visual effect
@@ -268,14 +268,8 @@ export class Chart<Metadata = any> {
       .filter(l => l.type === LayerType.Trace) as TracesLayer<Metadata>[];
     const scatterLayers = this.optionalLayers
       .filter(l => l.type === LayerType.Scatter) as ScatterLayer<Metadata>[];
-    let flatPointsDC = traceLayers.reduce((points, layer) => {
-      return [...layer.linesDC.map(l => l.points).flat(), ...points];
-    }, [] as Point[]);
-    flatPointsDC = scatterLayers.reduce((points, layer) => {
-      return [...layer.points.map(p => ({ x: p.x, y: p.y })), ...points];
-    }, flatPointsDC);
 
-    const minMax = getXYMinMax(flatPointsDC);
+    const minMax = getXYMinMax(traceLayers, scatterLayers);
     const paddingFactorX = 0.02;
     const paddingFactorY = 0.03;
   
@@ -440,15 +434,10 @@ export class Chart<Metadata = any> {
     drawWithBounds(width, height);
 
     if (this.isResponsive) {
-      let debounceConfig: DebounceConfig = {
-        timeout: undefined,
-        time: 50
-      };
-
       // watch for changes in baseElement
       const resizeObserver = new ResizeObserver(entries => {
         const { blockSize: height, inlineSize: width } = entries[0].borderBoxSize[0];
-        debounce(debounceConfig, () => drawWithBounds(width, height));
+        drawWithBounds(width, height);
       });
       resizeObserver.observe(baseElement);
 
@@ -458,7 +447,7 @@ export class Chart<Metadata = any> {
       window.addEventListener("resize", e => {
         if (!e.view) return;
         const { innerHeight: height, innerWidth: width } = e.view;
-        debounce(debounceConfig, () => drawWithBounds(width, height));
+        drawWithBounds(width, height);
       });
     }
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,6 @@
-import { LayerArgs, ScaleNumeric, XY, Point, Scales, AxisType, D3Selection } from "./types";
+import { ScatterLayer } from "./layers/ScatterLayer";
+import { TracesLayer } from "./layers/TracesLayer";
+import { LayerArgs, ScaleNumeric, XY, Point, Scales, AxisType, D3Selection, PointWithMetadata } from "./types";
 
 const round = (num: number) => Math.floor(num * 10) / 10;
 
@@ -60,19 +62,23 @@ export const numScales = (bands: Partial<XY<string>> | undefined, layerArgs: Lay
   }
 }
 
-export const getXYMinMax = (points: Point[]) => {
-  const scales: Scales = {
+export const getXYMinMax = <Metadata>(
+  traceLayers: TracesLayer<Metadata>[],
+  scatterLayers: ScatterLayer<Metadata>[],
+) => {
+  const minMax: Scales = {
     x: { start: Infinity, end: -Infinity },
     y: { start: Infinity, end: -Infinity }
   };
-  for (let i = 0; i < points.length; i++) {
-    const { x, y } = points[i];
-    if (x < scales.x.start) scales.x.start = x;
-    if (x > scales.x.end) scales.x.end = x;
-    if (y < scales.y.start) scales.y.start = y;
-    if (y > scales.y.end) scales.y.end = y;
-  }
-  return scales;
+
+  iterateOverPoints<Metadata>(traceLayers, scatterLayers, ({ x, y }) => {
+    if (x < minMax.x.start) minMax.x.start = x;
+    if (x > minMax.x.end) minMax.x.end = x;
+    if (y < minMax.y.start) minMax.y.start = y;
+    if (y > minMax.y.end) minMax.y.end = y;
+  });
+
+  return minMax;
 };
 
 export const getSvgRectPath = (xStart: number, xEnd: number, yStart: number, yEnd: number) =>
@@ -113,16 +119,32 @@ export const drawLine = (
     .style("stroke", color).style("stroke-width", 0.5);
 }
 
-export type DebounceConfig = {
-  timeout: NodeJS.Timeout | undefined,
-  time: number
-}
+export const iterateOverPoints = <Metadata>(
+  traceLayers: TracesLayer<Metadata>[],
+  scatterLayers: ScatterLayer<Metadata>[],
+  callback: (point: PointWithMetadata<Metadata>) => void
+) => {
+  for (let i = 0; i < traceLayers.length; i++) {
+    const traceLayer = traceLayers[i];
+    for (let j = 0; j < traceLayer.linesDC.length; j++) {
+      const line = traceLayer.linesDC[j];
+      for (let k = 0; k < line.points.length; k++) {
+        const point = line.points[k];
+        const pointWithMetadata: PointWithMetadata<Metadata> = {
+          x: point.x,
+          y: point.y,
+          bands: line.bands,
+          metadata: line.metadata,
+        }
+        callback(pointWithMetadata);
+      }
+    }
+  }
 
-// DebounceConfig in the first arg, we can let multiple debounced
-// calls share a timeout
-export const debounce = (cfg: DebounceConfig, callback: () => any) => {
-  clearTimeout(cfg.timeout);
-  cfg.timeout = setTimeout(() => {
-    callback();
-  }, cfg.time);
+  for (let i = 0; i < scatterLayers.length; i++) {
+    const scatterLayer = scatterLayers[i];
+    for (let j = 0; j < scatterLayer.points.length; j++) {
+      callback(scatterLayer.points[j]);
+    }
+  }
 };

--- a/src/layers/AreaLayer.ts
+++ b/src/layers/AreaLayer.ts
@@ -1,7 +1,7 @@
 import { LayerArgs, Point, ZoomExtents, ZoomProperties } from "@/types";
 import { LayerType, OptionalLayer } from "./Layer";
 import { TracesLayer } from "./TracesLayer";
-import { customLineGen, getSvgRectPath, getXYMinMax, numScales } from "@/helpers";
+import { customLineGen, getSvgRectPath, numScales } from "@/helpers";
 
 type LineBoundaryInfo = {
   xMinDC: number,
@@ -40,7 +40,11 @@ export class AreaLayer<Metadata> extends OptionalLayer {
         const scales = numScales(line.bands, layerArgs);
         const lineSC = layer.lowResLinesSC[lineIdx];
 
-        const { x: xMinMax } = getXYMinMax(line.points);
+        const xMinMax = { start: Infinity, end: -Infinity };
+        line.points.forEach(({ x }) => {
+          if (x < xMinMax.start) xMinMax.start = x;
+          if (x > xMinMax.end) xMinMax.end = x;
+        });
 
         // For each line, we now create a "canvas path", which we will later
         // use for determining whether a given point lies within the inside of

--- a/src/layers/TooltipsLayer.ts
+++ b/src/layers/TooltipsLayer.ts
@@ -3,7 +3,7 @@ import { LayerType, OptionalLayer } from "./Layer";
 import { TracesLayer } from "./TracesLayer";
 import { AxisType, D3Selection, LayerArgs, Point, PointWithMetadata, ScaleNumeric, XY } from "@/types";
 import { ScatterLayer } from "./ScatterLayer";
-import { mapScales, numScales } from "@/helpers";
+import { iterateOverPoints, mapScales, numScales } from "@/helpers";
 
 export type TooltipHtmlCallback<Metadata> =
   (pointWithMetadata: PointWithMetadata<Metadata>) => string
@@ -69,7 +69,8 @@ export class TooltipsLayer<Metadata> extends OptionalLayer {
     eventCC: d3.ClientPointEvent,
     layerArgs: LayerArgs,
     tooltip: D3Selection<HTMLDivElement>,
-    flatPointsDC: PointWithMetadata<Metadata>[],
+    traceLayers: TracesLayer<Metadata>[],
+    scatterLayers: ScatterLayer<Metadata>[]
   ) => {
     // d3.pointer converts coords from CC to SC
     const pointer = d3.pointer(eventCC);
@@ -107,7 +108,9 @@ export class TooltipsLayer<Metadata> extends OptionalLayer {
     // distance if the axes are not the same aspect ratio as the height and
     // width of the svg)
     let minDistanceNormalized = Infinity;
-    const minPointDC = flatPointsDC.reduce((minPDC, pDC) => {
+    let minPointDC: PointWithMetadata<Metadata> = { x: 0, y: 0 };
+
+    iterateOverPoints<Metadata>(traceLayers, scatterLayers, pDC => {
       const bands = pDC.bands || {};
       const coordsDC = {
         x: bands.x ? catScalesPointerCoordsDC.x[bands.x] : mainScalesPointerCoordsDC.x,
@@ -121,20 +124,20 @@ export class TooltipsLayer<Metadata> extends OptionalLayer {
         // If using distanceAxis, compare distances along that axis first.
         // If points have equal distance on that axis (as in a stacked bar chart, or a histogram with multiple traces),
         // use full distance to break ties.
-        const [distanceOnAxisSC, minDistanceOnAxisSC] = [pDC, minPDC].map((point) => {
+        const [distanceOnAxisSC, minDistanceOnAxisSC] = [pDC, minPointDC].map((point) => {
           // This is equivalent to `getDistanceSqSC` but on only one axis.
           const coordsSC = coordsDC[distAx] * scalingFactors[distAx];
           const pointSC = point[distAx] * scalingFactors[distAx];
 
           return (coordsSC - pointSC) ** 2;
         });
-        if (distanceOnAxisSC > minDistanceOnAxisSC) return minPDC;
+        if (distanceOnAxisSC > minDistanceOnAxisSC) return;
       }
       const distanceSC = this.getDistanceSqSC(coordsDC, pDC, scalingFactors);
-      if (distanceSC >= minDistanceNormalized) return minPDC;
+      if (distanceSC >= minDistanceNormalized) return;
       minDistanceNormalized = distanceSC;
-      return pDC;
-    }, { x: 0, y: 0 });
+      minPointDC = pDC;
+    });
 
     const numericalScales = numScales(minPointDC.bands, layerArgs);
 
@@ -178,14 +181,6 @@ export class TooltipsLayer<Metadata> extends OptionalLayer {
       .style("position", "fixed")
       .style("pointer-events", "none") as any as D3Selection<HTMLDivElement>;
     
-    let flatPointsDC = traceLayers.reduce((pointsWithMetadata, layer) => {
-      const layerPointsWithMetadata = layer.linesDC.flatMap(({ points, metadata, bands }) => {
-        return points.map(p => ({ ...p, metadata, bands }) );
-      });
-      return [...layerPointsWithMetadata, ...pointsWithMetadata];
-    }, [] as PointWithMetadata<Metadata>[]);
-    flatPointsDC = scatterLayers.reduce((points, layer) => ([...layer.points, ...points]), flatPointsDC);
-
     const svg = layerArgs.coreLayers[LayerType.Svg];
     let timerFlag: NodeJS.Timeout | undefined = undefined;
     let hideTooltip = false;
@@ -194,7 +189,7 @@ export class TooltipsLayer<Metadata> extends OptionalLayer {
         // in laggy situation there is a persistent phantom tooltip left behind.
         // this gets rid of any other tooltips that are not meant to be there
         document.querySelectorAll(`*[id*="${this.type}"]`)?.forEach(el => el.innerHTML = "");
-        this.handleMouseMove(e, layerArgs, tooltip, flatPointsDC);
+        this.handleMouseMove(e, layerArgs, tooltip, traceLayers, scatterLayers);
         timerFlag = setTimeout(() => {
           timerFlag = undefined;
         }, 25);


### PR DESCRIPTION
I saw how small the diff was and just decided to do these two in one PR. This removes debounce and adds iterators for all points. We are no longer creating a massive copy of the data!