### PR TITLE
Better default formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "d3-axis": "^3.0.0",
         "d3-brush": "^3.0.0",
+        "d3-format": "^3.1.2",
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
@@ -2408,9 +2409,10 @@
       }
     },
     "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reside-ic/skadi-chart",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reside-ic/skadi-chart",
-      "version": "1.1.14",
+      "version": "1.1.15",
       "dependencies": {
         "d3-axis": "^3.0.0",
         "d3-brush": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "d3-axis": "^3.0.0",
     "d3-brush": "^3.0.0",
+    "d3-format": "^3.1.2",
     "d3-scale": "^4.0.2",
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reside-ic/skadi-chart",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "type": "module",
   "files": [
     "dist"

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -37,7 +37,7 @@ type PartialChartOptions = {
 // large values and standard form for small values, 0.00000026 -> 2.6e-7
 const formatLarge = d3.format('.2~s');
 const formatSmall = d3.format('.2~g');
-const defaultFormatter = (val: number) => Math.abs(val) < 1
+export const defaultFormatter = (val: number) => Math.abs(val) < 1
   ? formatSmall(val)
   : formatLarge(val)
 

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -33,6 +33,14 @@ type PartialChartOptions = {
   },
 }
 
+// an SI-prefix with 2 significant figures and no trailing zeros, 42e6 -> 42M for
+// large values and standard form for small values, 0.00000026 -> 2.6e-7
+const formatLarge = d3.format('.2~s');
+const formatSmall = d3.format('.2~g');
+const defaultFormatter = (val: number) => Math.abs(val) < 1
+  ? formatSmall(val)
+  : formatLarge(val)
+
 export class Chart<Metadata = any> {
   id: string;
   optionalLayers: AllOptionalLayers[] = [];
@@ -41,8 +49,8 @@ export class Chart<Metadata = any> {
     animationDuration: 350,
     tickConfig: {
       numerical: {
-        x: { specifier: ".2~s" }, // an SI-prefix with 2 significant figures and no trailing zeros, 42e6 -> 42M
-        y: { specifier: ".2~s" },
+        x: { formatter: defaultFormatter },
+        y: { formatter: defaultFormatter },
       },
       categorical: { x: {}, y: {} },
     } as LayerArgs["globals"]["tickConfig"],

--- a/src/d3.ts
+++ b/src/d3.ts
@@ -8,3 +8,4 @@ export { line, type Line } from "d3-shape";
 export { create, type BaseType, type Selection, type ClientPointEvent, pointer } from "d3-selection";
 export { brush, type D3BrushEvent } from "d3-brush";
 export { scaleBand, scaleLinear, scaleLog, type NumberValue, type ScaleBand, type ScaleContinuousNumeric } from "d3-scale";
+export { format } from "d3-format";

--- a/tests/unit/chart.test.ts
+++ b/tests/unit/chart.test.ts
@@ -1,4 +1,4 @@
-import { Chart } from "../../src/Chart";
+import { Chart, defaultFormatter } from "../../src/Chart";
 import { AxesLayer } from "@/layers/AxesLayer";
 import { TracesLayer } from "@/layers/TracesLayer";
 import { ZoomLayer } from "@/layers/ZoomLayer";
@@ -144,5 +144,14 @@ describe("Chart tests", () => {
 
     expect(autoscaled.x.end).toBeCloseTo(5 * logXPaddingFactor);
     expect(autoscaled.y.end).toBeCloseTo(3 * logYPaddingFactor);
+  });
+
+  test("default formatter is sensible for big and small numbers", () => {
+    let val = 1e6;
+    let formatted = defaultFormatter(val)
+    expect(formatted).toBe("1M")
+    val = 1e-8;
+    formatted = defaultFormatter(val)
+    expect(formatted).toBe("1e-8")
   });
 });


### PR DESCRIPTION
SI prefixes for smaller than 1 values looks a bit weird, especially with `M` meaning mega and `m` meaning micro, instead we switch the formatting based on whether they are big or small and do SI prefixes for only bigger numbers and standard form for smaller numbers (normal decimal but standard form kicks in for values < `1e-6`)