### PR TITLE
Allow easy user defined zoom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@reside-ic/skadi-chart",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@reside-ic/skadi-chart",
-      "version": "1.1.15",
+      "version": "1.1.16",
       "dependencies": {
         "d3-axis": "^3.0.0",
         "d3-brush": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reside-ic/skadi-chart",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "type": "module",
   "files": [
     "dist"

--- a/src/Chart.ts
+++ b/src/Chart.ts
@@ -3,7 +3,7 @@ import { AxesLayer } from "./layers/AxesLayer";
 import { TracesLayer, TracesOptions } from "./layers/TracesLayer";
 import { ZoomLayer, ZoomOptions } from "./layers/ZoomLayer";
 import { TooltipHtmlCallback, TooltipsLayer } from "./layers/TooltipsLayer";
-import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, ZoomExtents, PartialScales, Scales, ScatterPoints, XY, ScaleNumeric, AxisType, CategoricalScaleConfig, ClipPathBounds, TickConfig } from "./types";
+import { AllOptionalLayers, Bounds, D3Selection, LayerArgs, Lines, ZoomExtents, PartialScales, Scales, ScatterPoints, XY, ScaleNumeric, AxisType, CategoricalScaleConfig, ClipPathBounds, TickConfig, ZoomProperties } from "./types";
 import { LayerType, LifecycleHooks, OptionalLayer } from "./layers/Layer";
 import { GridLayer, GridOptions } from "./layers/GridLayer";
 import html2canvas from "html2canvas";
@@ -62,6 +62,7 @@ export class Chart<Metadata = any> {
     x: { start: -Infinity, end: Infinity },
     y: { start: -Infinity, end: Infinity }
   };
+  handleZoom: (zoomProperties: ZoomProperties) => Promise<void> = async () => {};
 
   constructor(options?: PartialChartOptions) {
     this.options = {
@@ -421,6 +422,9 @@ export class Chart<Metadata = any> {
     baseElement.childNodes.forEach(n => n.remove());
 
     this.optionalLayers.forEach(l => l.draw(layerArgs, initialDomain));
+
+    const zoomLayer = this.optionalLayers.find(l => l.type === LayerType.Zoom) as ZoomLayer | undefined ;
+    if (zoomLayer) this.handleZoom = zoomLayer.handleZoom;
 
     baseElement.append(layerArgs.coreLayers[LayerType.Svg].node()!);
   };

--- a/src/layers/ZoomLayer.ts
+++ b/src/layers/ZoomLayer.ts
@@ -11,6 +11,7 @@ export class ZoomLayer extends OptionalLayer {
   zooming = false;
   selectionMask: D3Selection<SVGRectElement> | null = null;
   overlay: D3Selection<SVGRectElement> | null = null;
+  handleZoom: (zoomProperties: ZoomProperties) => Promise<void> = async () => {};
 
   constructor(public options: ZoomOptions) {
     super();
@@ -38,27 +39,6 @@ export class ZoomLayer extends OptionalLayer {
     } else {
       return [[x0, y0], [x1, y1]];
     }
-  };
-
-  private handleZoom = async (zoomProperties: ZoomProperties, layerArgs: LayerArgs) => {
-    if (this.zooming) return;
-    this.zooming = true;
-
-    const { x: scaleX, y: scaleY } = layerArgs.scaleConfig.numericalScales;
-
-    layerArgs.optionalLayers.forEach(layer => layer.beforeZoom(zoomProperties));
-
-    // updates the scales which are implicitly used by a lot of other
-    // components
-    if (zoomProperties.x) scaleX.domain(zoomProperties.x);
-    if (zoomProperties.y) scaleY.domain(zoomProperties.y);
-
-    const promises: Promise<void>[] = [];
-    layerArgs.optionalLayers.forEach(layer => promises.push(layer.zoom(zoomProperties)));
-    await Promise.all(promises);
-
-    layerArgs.optionalLayers.forEach(layer => layer.afterZoom(zoomProperties));
-    this.zooming = false;
   };
 
   private handleBrushEnd = (event: d3.D3BrushEvent<Point>, brushLayer: D3Selection<SVGGElement>, layerArgs: LayerArgs) => {
@@ -99,7 +79,7 @@ export class ZoomLayer extends OptionalLayer {
       y: [extentYStart, extentYEnd],
       eventType: "brush"
     };
-    this.handleZoom(zoomProperties, layerArgs);
+    this.handleZoom(zoomProperties);
   };
 
   private handleBrushMove = (event: d3.D3BrushEvent<Point>, layerArgs: LayerArgs) => {
@@ -182,7 +162,27 @@ export class ZoomLayer extends OptionalLayer {
       .style("display", "none")
       .style("mask-image", `url(#${overlayMaskId}), url(#${selectionMaskId})`)
       .style("mask-composite", "subtract") as any as D3Selection<SVGRectElement>;
-    
+
+    this.handleZoom = async (zoomProperties: ZoomProperties) => {
+      if (this.zooming) return;
+      this.zooming = true;
+
+      const { x: scaleX, y: scaleY } = layerArgs.scaleConfig.numericalScales;
+
+      layerArgs.optionalLayers.forEach(layer => layer.beforeZoom(zoomProperties));
+
+      // updates the scales which are implicitly used by a lot of other
+      // components
+      if (zoomProperties.x) scaleX.domain(zoomProperties.x);
+      if (zoomProperties.y) scaleY.domain(zoomProperties.y);
+
+      const promises: Promise<void>[] = [];
+      layerArgs.optionalLayers.forEach(layer => promises.push(layer.zoom(zoomProperties)));
+      await Promise.all(promises);
+
+      layerArgs.optionalLayers.forEach(layer => layer.afterZoom(zoomProperties));
+      this.zooming = false;
+    };
 
     d3Brush.on("start", () => layerArgs.optionalLayers.forEach(l => l.brushStart()));
     d3Brush.on("brush", e => this.handleBrushMove(e, layerArgs));
@@ -205,6 +205,6 @@ export class ZoomLayer extends OptionalLayer {
     }
 
     layerArgs.coreLayers[LayerType.Svg]
-      .on("dblclick",() => this.handleZoom(dblClickZoomProperties, layerArgs));
+      .on("dblclick",() => this.handleZoom(dblClickZoomProperties));
   };
 };


### PR DESCRIPTION
this doesnt change any visible functionality, all it does is move code around so we (as a user of skadi chart) can easily invoke zoom. How does this make it easier? Before this change the signature of the function handle zoom was:

```ts
function(zoomProperties: ZoomProperties, layerArgs: LayerArgs): Promise<void>
```

however a user does not know the layer args and cannot provide it to the function, so instead of making this a class method, i made it a closure that captures the layer args from the draw function and now the signature is

```ts
function(zoomProperties: ZoomProperties): Promise<void>
```

which means the user can just pull this out in a custom layer/custom lifecycle hook and freely use it with just the zoom properties

context: i need linked zoom for skadi app with multiple graphs all zooming in to the same region and wanted the simplest way to do that without changing skadi chart much given the interface refactor thats going on in the background