### PR TITLE
Add configuration of inner padding (for categorical axes)

### DIFF
--- a/src/Chart/README.md
+++ b/src/Chart/README.md
@@ -1,0 +1,5 @@
+# Skadi Chart
+
+This .md is a scratchpad to keep track of things that we will want to include in the new README once the new interface / refactor is complete.
+
+1. Document that the band scale inner padding config option has units such that e.g. 0.1 means "10% of the band's width".

--- a/src/Chart/config/Config.ts
+++ b/src/Chart/config/Config.ts
@@ -2,7 +2,8 @@ import { ChartType, MixNewFlags } from "@/types";
 import {
   AxisArgs,
   AxisConfig,
-  Categories,
+  CategoriesArgs,
+  CategoriesConfig,
   CurrFlags,
   CurrOutput,
   CurrState,
@@ -16,7 +17,7 @@ import { doXY, makeObjXY } from "@/helpers";
 
 export class Config<M, T extends ChartType, Flags extends CurrFlags> {
   private axes: AxisConfig = { x: { label: { text: "", padding: 50 } }, y: { label: { text: "", padding: 40 } } };
-  private categories: Categories["categoricalXY"] = { x: [], y: [] };
+  private categories: CategoriesConfig["categoricalXY"] = { x: { labels: [], innerPadding: 0.1 }, y: { labels: [], innerPadding: 0.1 } };
   private scales: ScaleOutput[ChartType] | null = null;
 
   private constructor(private prevOutput: PrevOutput<M>) {};
@@ -40,20 +41,25 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
     return this as This<M, T, Flags>;
   }
 
-  configureCategories(args: Categories[T]) {
-    if ("x" in args && args.x.length > 0) {
-      this.categories.x = args.x;
-    }
-    if ("y" in args && args.y.length > 0) {
-      this.categories.y = args.y;
-    }
+  configureCategories(args: CategoriesArgs[T]) {
+    doXY(axis => {
+      if (axis in args) {
+        const { labels, innerPadding } = (args as CategoriesArgs["categoricalXY"])[axis];
+        if (labels.length > 0) {
+          this.categories[axis].labels = labels;
+          if (innerPadding !== undefined) {
+            this.categories[axis].innerPadding = innerPadding;
+          }
+        }
+      }
+    });
     type NewFlags = MixNewFlags<CurrFlags, Flags, { hasConfiguredCategories: true }>
     return this as This<M, T, NewFlags>;
   };
 
   configureScales(scaleArgs: ScaleArgs = {}) {
     doXY(axis => {
-      if (categoricalChartTypes[axis].includes(this.prevOutput.chartType) && !this.categories[axis].length) {
+      if (categoricalChartTypes[axis].includes(this.prevOutput.chartType) && !this.categories[axis].labels.length) {
         throw new Error("Categories must be configured before scales")
       }
     });

--- a/src/Chart/config/Config.ts
+++ b/src/Chart/config/Config.ts
@@ -32,7 +32,7 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
     doXY(axis => {
       if (args[axis]?.label) {
         this.axes[axis].label.text = args[axis].label.text;
-        if (args[axis].label.padding) {
+        if (args[axis].label.padding !== undefined) {
           this.axes[axis].label.padding = args[axis].label.padding;
         }
       }

--- a/src/Chart/config/Config.ts
+++ b/src/Chart/config/Config.ts
@@ -2,8 +2,7 @@ import { ChartType, MixNewFlags } from "@/types";
 import {
   AxisArgs,
   AxisConfig,
-  CategoriesArgs,
-  CategoriesConfig,
+  Categories,
   CurrFlags,
   CurrOutput,
   CurrState,
@@ -16,8 +15,11 @@ import { categoricalChartTypes, processScaleArgs, ScaleArgs, ScaleArgsParsed, Sc
 import { doXY, makeObjXY } from "@/helpers";
 
 export class Config<M, T extends ChartType, Flags extends CurrFlags> {
-  private axes: AxisConfig = { x: { label: { text: "", padding: 50 } }, y: { label: { text: "", padding: 40 } } };
-  private categories: CategoriesConfig["categoricalXY"] = { x: { labels: [], innerPadding: 0.1 }, y: { labels: [], innerPadding: 0.1 } };
+  private axes: AxisConfig["categoricalXY"] = {
+    x: { label: { text: "", padding: 50 }, innerPadding: 0.1 },
+    y: { label: { text: "", padding: 40 }, innerPadding: 0.1 },
+  };
+  private categories: Categories["categoricalXY"] = { x: [], y: [] };
   private scales: ScaleOutput[ChartType] | null = null;
 
   private constructor(private prevOutput: PrevOutput<M>) {};
@@ -29,7 +31,7 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
     return new Config<M, T, NewFlags>(prevOutput) as This<M, T, NewFlags>;
   };
 
-  configureAxes(args: AxisArgs = {}) {
+  configureAxes(args: AxisArgs[T] = {}) {
     doXY(axis => {
       if (args[axis]?.label) {
         this.axes[axis].label.text = args[axis].label.text;
@@ -37,29 +39,27 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
           this.axes[axis].label.padding = args[axis].label.padding;
         }
       }
+      if (args[axis] && "innerPadding" in args[axis] && args[axis].innerPadding !== undefined) {
+        this.axes[axis].innerPadding = args[axis].innerPadding;
+      }
     });
     return this as This<M, T, Flags>;
   }
 
-  configureCategories(args: CategoriesArgs[T]) {
-    doXY(axis => {
-      if (axis in args) {
-        const { labels, innerPadding } = (args as CategoriesArgs["categoricalXY"])[axis];
-        if (labels.length > 0) {
-          this.categories[axis].labels = labels;
-          if (innerPadding !== undefined) {
-            this.categories[axis].innerPadding = innerPadding;
-          }
-        }
-      }
-    });
+  configureCategories(args: Categories[T]) {
+    if ("x" in args && args.x.length > 0) {
+      this.categories.x = args.x;
+    }
+    if ("y" in args && args.y.length > 0) {
+      this.categories.y = args.y;
+    }
     type NewFlags = MixNewFlags<CurrFlags, Flags, { hasConfiguredCategories: true }>
     return this as This<M, T, NewFlags>;
   };
 
   configureScales(scaleArgs: ScaleArgs = {}) {
     doXY(axis => {
-      if (categoricalChartTypes[axis].includes(this.prevOutput.chartType) && !this.categories[axis].labels.length) {
+      if (categoricalChartTypes[axis].includes(this.prevOutput.chartType) && !this.categories[axis].length) {
         throw new Error("Categories must be configured before scales")
       }
     });
@@ -73,7 +73,7 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
         scaleArgsParsed[axis].extents.end = scaleArgs[axis].extents.end;
       }
     });
-    this.scales = processScaleArgs(scaleArgsParsed, this.prevOutput, this.categories);
+    this.scales = processScaleArgs(scaleArgsParsed, this.prevOutput, this.categories, this.axes);
     type NewFlags = MixNewFlags<CurrFlags, Flags, { hasConfiguredScale: true }>
     return this as This<M, T, NewFlags>;
   };

--- a/src/Chart/config/scales.ts
+++ b/src/Chart/config/scales.ts
@@ -4,7 +4,7 @@ import { CurrOutput as PrevOutput, CurrState as PrevState } from "../data/types"
 import { iterateAllPoints, IterateAllPointsArgs } from "../data/utils"
 import { anyXY, doXY, makeObjXY } from "@/helpers"
 import { SingleRange } from "../base/types";
-import { Categories } from "./types";
+import { CategoriesConfig } from "./types";
 import { getInner } from "../base/utils";
 
 type SingleAutoScale = { start: number | "auto", end: number | "auto" }
@@ -80,7 +80,7 @@ export const categoricalChartTypes: XY<ChartType[]> = {
 }
 
 export const processScaleArgs = <M>(
-  args: ScaleArgsParsed, prevOutput: PrevOutput<M>, categories: Categories["categoricalXY"]
+  args: ScaleArgsParsed, prevOutput: PrevOutput<M>, categories: CategoriesConfig["categoricalXY"]
 ): ScaleOutput[ChartType] => {
   // get max extents
   const extents = getXYMinMax<M>(prevOutput.chartType, prevOutput.dataState);
@@ -139,11 +139,12 @@ export const processScaleArgs = <M>(
 
     const axisRange = ranges[axis];
     const d3Scale = d3.scaleBand()
-      .domain(categories[axis])
-      .range([ axisRange.start, axisRange.end ]);
+      .domain(categories[axis].labels)
+      .range([ axisRange.start, axisRange.end ])
+      .paddingInner(categories[axis].innerPadding);
     const categoryWidth = d3Scale.bandwidth();
 
-    const categoriesScales = categories[axis].reduce((acc, category) => {
+    const categoriesScales = categories[axis].labels.reduce((acc, category) => {
       const categoryStartSC = d3Scale(category)!;
       const categoryRange = axis === "x"
         ? [categoryStartSC, categoryStartSC + categoryWidth]

--- a/src/Chart/config/scales.ts
+++ b/src/Chart/config/scales.ts
@@ -4,7 +4,7 @@ import { CurrOutput as PrevOutput, CurrState as PrevState } from "../data/types"
 import { iterateAllPoints, IterateAllPointsArgs } from "../data/utils"
 import { anyXY, doXY, makeObjXY } from "@/helpers"
 import { SingleRange } from "../base/types";
-import { CategoriesConfig } from "./types";
+import { AxisConfig, Categories } from "./types";
 import { getInner } from "../base/utils";
 
 type SingleAutoScale = { start: number | "auto", end: number | "auto" }
@@ -80,7 +80,10 @@ export const categoricalChartTypes: XY<ChartType[]> = {
 }
 
 export const processScaleArgs = <M>(
-  args: ScaleArgsParsed, prevOutput: PrevOutput<M>, categories: CategoriesConfig["categoricalXY"]
+  args: ScaleArgsParsed,
+  prevOutput: PrevOutput<M>,
+  categories: Categories["categoricalXY"],
+  axes: AxisConfig["categoricalXY"],
 ): ScaleOutput[ChartType] => {
   // get max extents
   const extents = getXYMinMax<M>(prevOutput.chartType, prevOutput.dataState);
@@ -139,12 +142,12 @@ export const processScaleArgs = <M>(
 
     const axisRange = ranges[axis];
     const d3Scale = d3.scaleBand()
-      .domain(categories[axis].labels)
+      .domain(categories[axis])
       .range([ axisRange.start, axisRange.end ])
-      .paddingInner(categories[axis].innerPadding);
+      .paddingInner(axes[axis].innerPadding);
     const categoryWidth = d3Scale.bandwidth();
 
-    const categoriesScales = categories[axis].labels.reduce((acc, category) => {
+    const categoriesScales = categories[axis].reduce((acc, category) => {
       const categoryStartSC = d3Scale(category)!;
       const categoryRange = axis === "x"
         ? [categoryStartSC, categoryStartSC + categoryWidth]

--- a/src/Chart/config/types.ts
+++ b/src/Chart/config/types.ts
@@ -40,41 +40,36 @@ export type This<M, T extends ChartType, Flags extends CurrFlags> =
   Omit<Config<M, T, Flags>, MethodsToRemove<T, Flags>>
 
 
-export type AxisArgs = Partial<XY<{
-  label?: {
-    text: string,
-    padding?: number,
-  }
-}>>
-export type AxisConfig = XY<{
-  label: {
-    text: string,
-    padding: number,
-  }
-}>;
-
-
-type CategoriesPropertiesByChartType<Props> = HasAllKeys<ChartType, {
+export type Categories = HasAllKeys<ChartType, {
   default: never,
-  categoricalX: { x: Props },
-  categoricalY: { y: Props },
-  categoricalXY: XY<Props>,
+  categoricalX: { x: string[] },
+  categoricalY: { y: string[] },
+  categoricalXY: { x: string[], y: string[] },
 }>
 
-export type CategoriesArgs = CategoriesPropertiesByChartType<{
-  labels: string[],
-  innerPadding?: number,
+type AxisArgsBase = { label?: { text: string, padding?: number } }
+type AxisArgsCategorical = AxisArgsBase & { innerPadding?: number }
+type AxisConfigNumerical = { label: { text: string, padding: number } }
+type AxisConfigCategorical = AxisConfigNumerical & { innerPadding: number }
+
+export type AxisArgs = HasAllKeys<ChartType, {
+  default: Partial<XY<AxisArgsBase>>,
+  categoricalX: Partial<{ x: AxisArgsCategorical } & { y: AxisArgsBase }>,
+  categoricalY: Partial<{ x: AxisArgsBase } & { y: AxisArgsCategorical }>,
+  categoricalXY: Partial<{ x: AxisArgsCategorical } & { y: AxisArgsCategorical }>,
 }>
 
-export type CategoriesConfig = CategoriesPropertiesByChartType<{
-  labels: string[],
-  innerPadding: number,
+export type AxisConfig = HasAllKeys<ChartType, {
+  default: XY<AxisConfigNumerical>,
+  categoricalX: { x: AxisConfigCategorical } & { y: AxisConfigNumerical },
+  categoricalY: { x: AxisConfigNumerical } & { y: AxisConfigCategorical },
+  categoricalXY: { x: AxisConfigCategorical } & { y: AxisConfigCategorical },
 }>
 
 
 export type CurrState<T extends ChartType> = {
-  axes: AxisConfig,
-  categories: CategoriesConfig[T],
+  axes: AxisConfig[T],
+  categories: Categories[T],
   scales: ScaleOutput[T],
 }
 

--- a/src/Chart/config/types.ts
+++ b/src/Chart/config/types.ts
@@ -40,14 +40,6 @@ export type This<M, T extends ChartType, Flags extends CurrFlags> =
   Omit<Config<M, T, Flags>, MethodsToRemove<T, Flags>>
 
 
-
-export type Categories = HasAllKeys<ChartType, {
-  default: never,
-  categoricalX: { x: string[] },
-  categoricalY: { y: string[] },
-  categoricalXY: { x: string[], y: string[] },
-}>
-
 export type AxisArgs = Partial<XY<{
   label?: {
     text: string,
@@ -62,10 +54,27 @@ export type AxisConfig = XY<{
 }>;
 
 
+type CategoriesPropertiesByChartType<Props> = HasAllKeys<ChartType, {
+  default: never,
+  categoricalX: { x: Props },
+  categoricalY: { y: Props },
+  categoricalXY: XY<Props>,
+}>
+
+export type CategoriesArgs = CategoriesPropertiesByChartType<{
+  labels: string[],
+  innerPadding?: number,
+}>
+
+export type CategoriesConfig = CategoriesPropertiesByChartType<{
+  labels: string[],
+  innerPadding: number,
+}>
+
 
 export type CurrState<T extends ChartType> = {
   axes: AxisConfig,
-  categories: Categories[T],
+  categories: CategoriesConfig[T],
   scales: ScaleOutput[T],
 }
 

--- a/src/Chart/visual/layers/AxesLayer.ts
+++ b/src/Chart/visual/layers/AxesLayer.ts
@@ -69,7 +69,7 @@ export class AxesLayer<M> extends Layer<M, null> {
     }
   };
 
-  private drawCategorical = (axis: XorY, { scale, categories }: ScaleCategorical) => {
+  private drawCategorical = (axis: XorY, scaleCategorical: ScaleCategorical) => {
     const { getHtmlId, bounds } = this.prevOutput.baseState;
     const inner = getInner(bounds);
     const translation = axis === "x"
@@ -78,7 +78,8 @@ export class AxesLayer<M> extends Layer<M, null> {
     const axisConstructor = axis === "x" ? d3.axisBottom : d3.axisLeft;
     const tickPadding = 30; // This will become a configurable option.
     
-    const categoricalAxis = axisConstructor(scale).tickPadding(tickPadding);
+    const bandScale = scaleCategorical.scale; // The main, "outer" scale, containing all the bands
+    const categoricalAxis = axisConstructor(bandScale).tickPadding(tickPadding);
     const axisGElement = this.coreLayers[CoreLayer.Svg]
       .append("g")
       .attr("id", `${axis}-categorical-${getHtmlId(VisualLayer.Axes)}`)
@@ -87,8 +88,9 @@ export class AxesLayer<M> extends Layer<M, null> {
       .call(categoricalAxis);
     axisGElement.select(".domain").style("stroke-opacity", 0);
 
-    Object.entries(categories).forEach(([_, categoryScale]) => {
-      this.drawNumerical(axis, categoryScale, false);
+    const numericalScales = scaleCategorical.categories; // Each band's "inner" scale
+    Object.entries(numericalScales).forEach(([_, scale]) => {
+      this.drawNumerical(axis, scale, false);
     });
   };
 

--- a/src/demo/NewSkadiChart.vue
+++ b/src/demo/NewSkadiChart.vue
@@ -114,18 +114,12 @@ const renderChart = (chartType: ChartType) => {
       .startData()
       .startConfig()
       .configureAxes({
-        x: { label: { text: "X Category", padding: 70 } },
-        y: { label: { text: "Y Category", padding: 50 } },
+        x: { label: { text: "X Category", padding: 70 }, innerPadding: 0.2 },
+        y: { label: { text: "Y Category", padding: 50 }, innerPadding: 0.25 },
       })
       .configureCategories({
-        x: {
-          labels: ["A", "B", "C"],
-          innerPadding: 0.2,
-        },
-        y: {
-          labels: ["Category A", "Category B"],
-          innerPadding: 0.25,
-        },
+        x: ["A", "B", "C"],
+        y: ["Category A", "Category B"],
       })
       .configureScales({
         x: { extents: { start: -20, end: 20 } },
@@ -146,7 +140,7 @@ const renderChart = (chartType: ChartType) => {
         x: { label: { text: "X Category", padding: 70 } },
         y: { label: { text: "Value" } },
       })
-      .configureCategories({ x: { labels: ["A", "B", "C"] } })
+      .configureCategories({ x: ["A", "B", "C"] })
       .configureScales({
         x: { extents: { start: 0, end: 40 } },
         y: { extents: { start: -500, end: 500 } },
@@ -163,10 +157,10 @@ const renderChart = (chartType: ChartType) => {
     .startConfig()
     .configureAxes({
       x: { label: { text: "Time" } },
-      y: { label: { text: "Y Category" } },
+      y: { label: { text: "Y Category" }, innerPadding: 0.1 },
     })
     .configureCategories({
-      y: { labels: ["Category A", "Category B"], innerPadding: 0.1 },
+      y: ["Category A", "Category B"],
     })
     .configureScales({
       x: { extents: { start: 0, end: 40 } },

--- a/src/demo/NewSkadiChart.vue
+++ b/src/demo/NewSkadiChart.vue
@@ -118,8 +118,14 @@ const renderChart = (chartType: ChartType) => {
         y: { label: { text: "Y Category", padding: 50 } },
       })
       .configureCategories({
-        x: ["A", "B", "C"],
-        y: ["Category A", "Category B"],
+        x: {
+          labels: ["A", "B", "C"],
+          innerPadding: 0.2,
+        },
+        y: {
+          labels: ["Category A", "Category B"],
+          innerPadding: 0.25,
+        },
       })
       .configureScales({
         x: { extents: { start: -20, end: 20 } },
@@ -140,9 +146,7 @@ const renderChart = (chartType: ChartType) => {
         x: { label: { text: "X Category", padding: 70 } },
         y: { label: { text: "Value" } },
       })
-      .configureCategories({
-        x: ["A", "B", "C"],
-      })
+      .configureCategories({ x: { labels: ["A", "B", "C"] } })
       .configureScales({
         x: { extents: { start: 0, end: 40 } },
         y: { extents: { start: -500, end: 500 } },
@@ -162,7 +166,7 @@ const renderChart = (chartType: ChartType) => {
       y: { label: { text: "Y Category" } },
     })
     .configureCategories({
-      y: ["Category A", "Category B"],
+      y: { labels: ["Category A", "Category B"], innerPadding: 0.1 },
     })
     .configureScales({
       x: { extents: { start: 0, end: 40 } },


### PR DESCRIPTION
Inner padding is the padding between bands of a band scale: https://d3js.org/d3-scale/band#band_paddingInner

It was the next on the list to be implemented because it's best to do so before we implement gridlines or zero/origin lines, since those will need to jump over inner padding.

The default padding should be > 0, so that ticks at the edges of bands do not get printed on top of each other. I chose `0.1` for the default value on both axes, which means '10% of band width'.

I chose to make the inner padding configuration become part of the `configureCategories()` step, because it needs to be set before `configureScales()` can be called.

Just like the distinction we have between `AxisArgs` and `AxisConfig`, where args means what the user passes in with various optionals, and config means an internal copy which is fully populated, there is now a pair of types `CategoriesArgs` and `CategoriesConfig`.