### PR TITLE
Categorical axes inner padding via configure axes

### DIFF
--- a/src/Chart/config/Config.ts
+++ b/src/Chart/config/Config.ts
@@ -2,8 +2,7 @@ import { ChartType, MixNewFlags } from "@/types";
 import {
   AxisArgs,
   AxisConfig,
-  CategoriesArgs,
-  CategoriesConfig,
+  Categories,
   CurrFlags,
   CurrOutput,
   CurrState,
@@ -16,8 +15,11 @@ import { categoricalChartTypes, processScaleArgs, ScaleArgs, ScaleArgsParsed, Sc
 import { doXY, makeObjXY } from "@/helpers";
 
 export class Config<M, T extends ChartType, Flags extends CurrFlags> {
-  private axes: AxisConfig = { x: { label: { text: "", padding: 50 } }, y: { label: { text: "", padding: 40 } } };
-  private categories: CategoriesConfig["categoricalXY"] = { x: { labels: [], innerPadding: 0.1 }, y: { labels: [], innerPadding: 0.1 } };
+  private axes: AxisConfig["categoricalXY"] = {
+    x: { label: { text: "", padding: 50 }, innerPadding: 0.1 },
+    y: { label: { text: "", padding: 40 }, innerPadding: 0.1 },
+  };
+  private categories: Categories["categoricalXY"] = { x: [], y: [] };
   private scales: ScaleOutput[ChartType] | null = null;
 
   private constructor(private prevOutput: PrevOutput<M>) {};
@@ -29,7 +31,7 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
     return new Config<M, T, NewFlags>(prevOutput) as This<M, T, NewFlags>;
   };
 
-  configureAxes(args: AxisArgs = {}) {
+  configureAxes(args: AxisArgs[T] = {}) {
     doXY(axis => {
       if (args[axis]?.label) {
         this.axes[axis].label.text = args[axis].label.text;
@@ -37,29 +39,27 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
           this.axes[axis].label.padding = args[axis].label.padding;
         }
       }
+      if (args[axis] && "innerPadding" in args[axis] && args[axis].innerPadding !== undefined) {
+        this.axes[axis].innerPadding = args[axis].innerPadding;
+      }
     });
     return this as This<M, T, Flags>;
   }
 
-  configureCategories(args: CategoriesArgs[T]) {
-    doXY(axis => {
-      if (axis in args) {
-        const { labels, innerPadding } = (args as CategoriesArgs["categoricalXY"])[axis];
-        if (labels.length > 0) {
-          this.categories[axis].labels = labels;
-          if (innerPadding !== undefined) {
-            this.categories[axis].innerPadding = innerPadding;
-          }
-        }
-      }
-    });
+  configureCategories(args: Categories[T]) {
+    if ("x" in args && args.x.length > 0) {
+      this.categories.x = args.x;
+    }
+    if ("y" in args && args.y.length > 0) {
+      this.categories.y = args.y;
+    }
     type NewFlags = MixNewFlags<CurrFlags, Flags, { hasConfiguredCategories: true }>
     return this as This<M, T, NewFlags>;
   };
 
   configureScales(scaleArgs: ScaleArgs = {}) {
     doXY(axis => {
-      if (categoricalChartTypes[axis].includes(this.prevOutput.chartType) && !this.categories[axis].labels.length) {
+      if (categoricalChartTypes[axis].includes(this.prevOutput.chartType) && !this.categories[axis].length) {
         throw new Error("Categories must be configured before scales")
       }
     });
@@ -73,7 +73,7 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
         scaleArgsParsed[axis].extents.end = scaleArgs[axis].extents.end;
       }
     });
-    this.scales = processScaleArgs(scaleArgsParsed, this.prevOutput, this.categories);
+    this.scales = processScaleArgs(scaleArgsParsed, this.prevOutput, this.categories, this.axes);
     type NewFlags = MixNewFlags<CurrFlags, Flags, { hasConfiguredScale: true }>
     return this as This<M, T, NewFlags>;
   };

--- a/src/Chart/config/scales.ts
+++ b/src/Chart/config/scales.ts
@@ -4,7 +4,7 @@ import { CurrOutput as PrevOutput, CurrState as PrevState } from "../data/types"
 import { iterateAllPoints, IterateAllPointsArgs } from "../data/utils"
 import { anyXY, doXY, makeObjXY } from "@/helpers"
 import { SingleRange } from "../base/types";
-import { CategoriesConfig } from "./types";
+import { AxisConfig, Categories } from "./types";
 import { getInner } from "../base/utils";
 
 type SingleAutoScale = { start: number | "auto", end: number | "auto" }
@@ -80,7 +80,10 @@ export const categoricalChartTypes: XY<ChartType[]> = {
 }
 
 export const processScaleArgs = <M>(
-  args: ScaleArgsParsed, prevOutput: PrevOutput<M>, categories: CategoriesConfig["categoricalXY"]
+  args: ScaleArgsParsed,
+  prevOutput: PrevOutput<M>,
+  categories: Categories["categoricalXY"],
+  axes: AxisConfig["categoricalXY"],
 ): ScaleOutput[ChartType] => {
   // get max extents
   const extents = getXYMinMax<M>(prevOutput.chartType, prevOutput.dataState);
@@ -139,12 +142,12 @@ export const processScaleArgs = <M>(
 
     const axisRange = ranges[axis];
     const d3Scale = d3.scaleBand()
-      .domain(categories[axis].labels)
+      .domain(categories[axis])
       .range([ axisRange.start, axisRange.end ])
-      .paddingInner(categories[axis].innerPadding);
+      .paddingInner(axes[axis].innerPadding);
     const categoryWidth = d3Scale.bandwidth();
 
-    const categoriesScales = categories[axis].labels.reduce((acc, category) => {
+    const categoriesScales = categories[axis].reduce((acc, category) => {
       const categoryStartSC = d3Scale(category)!;
       const categoryRange = axis === "x"
         ? [categoryStartSC, categoryStartSC + categoryWidth]

--- a/src/Chart/config/types.ts
+++ b/src/Chart/config/types.ts
@@ -40,41 +40,36 @@ export type This<M, T extends ChartType, Flags extends CurrFlags> =
   Omit<Config<M, T, Flags>, MethodsToRemove<T, Flags>>
 
 
-export type AxisArgs = Partial<XY<{
-  label?: {
-    text: string,
-    padding?: number,
-  }
-}>>
-export type AxisConfig = XY<{
-  label: {
-    text: string,
-    padding: number,
-  }
-}>;
-
-
-type CategoriesPropertiesByChartType<Props> = HasAllKeys<ChartType, {
+export type Categories = HasAllKeys<ChartType, {
   default: never,
-  categoricalX: { x: Props },
-  categoricalY: { y: Props },
-  categoricalXY: XY<Props>,
+  categoricalX: { x: string[] },
+  categoricalY: { y: string[] },
+  categoricalXY: { x: string[], y: string[] },
 }>
 
-export type CategoriesArgs = CategoriesPropertiesByChartType<{
-  labels: string[],
-  innerPadding?: number,
+type AxisArgsBase = { label?: { text: string, padding?: number } }
+type AxisArgsCategorical = AxisArgsBase & { innerPadding?: number }
+type AxisConfigNumerical = { label: { text: string, padding: number } }
+type AxisConfigCategorical = AxisConfigNumerical & { innerPadding: number }
+
+export type AxisArgs = HasAllKeys<ChartType, {
+  default: Partial<XY<AxisArgsBase>>,
+  categoricalX: Partial<{ x: AxisArgsCategorical } & { y: AxisArgsBase }>,
+  categoricalY: Partial<{ x: AxisArgsBase } & { y: AxisArgsCategorical }>,
+  categoricalXY: Partial<{ x: AxisArgsCategorical } & { y: AxisArgsCategorical }>,
 }>
 
-export type CategoriesConfig = CategoriesPropertiesByChartType<{
-  labels: string[],
-  innerPadding: number,
+export type AxisConfig = HasAllKeys<ChartType, {
+  default: XY<AxisConfigNumerical>,
+  categoricalX: { x: AxisConfigCategorical } & { y: AxisConfigNumerical },
+  categoricalY: { x: AxisConfigNumerical } & { y: AxisConfigCategorical },
+  categoricalXY: { x: AxisConfigCategorical } & { y: AxisConfigCategorical },
 }>
 
 
 export type CurrState<T extends ChartType> = {
-  axes: AxisConfig,
-  categories: CategoriesConfig[T],
+  axes: AxisConfig[T],
+  categories: Categories[T],
   scales: ScaleOutput[T],
 }
 

--- a/src/demo/NewSkadiChart.vue
+++ b/src/demo/NewSkadiChart.vue
@@ -114,18 +114,12 @@ const renderChart = (chartType: ChartType) => {
       .startData()
       .startConfig()
       .configureAxes({
-        x: { label: { text: "X Category", padding: 70 } },
-        y: { label: { text: "Y Category", padding: 50 } },
+        x: { label: { text: "X Category", padding: 70 }, innerPadding: 0.2 },
+        y: { label: { text: "Y Category", padding: 50 }, innerPadding: 0.25 },
       })
       .configureCategories({
-        x: {
-          labels: ["A", "B", "C"],
-          innerPadding: 0.2,
-        },
-        y: {
-          labels: ["Category A", "Category B"],
-          innerPadding: 0.25,
-        },
+        x: ["A", "B", "C"],
+        y: ["Category A", "Category B"],
       })
       .configureScales({
         x: { extents: { start: -20, end: 20 } },
@@ -146,7 +140,7 @@ const renderChart = (chartType: ChartType) => {
         x: { label: { text: "X Category", padding: 70 } },
         y: { label: { text: "Value" } },
       })
-      .configureCategories({ x: { labels: ["A", "B", "C"] } })
+      .configureCategories({ x: ["A", "B", "C"] })
       .configureScales({
         x: { extents: { start: 0, end: 40 } },
         y: { extents: { start: -500, end: 500 } },
@@ -163,10 +157,10 @@ const renderChart = (chartType: ChartType) => {
     .startConfig()
     .configureAxes({
       x: { label: { text: "Time" } },
-      y: { label: { text: "Y Category" } },
+      y: { label: { text: "Y Category" }, innerPadding: 0.1 },
     })
     .configureCategories({
-      y: { labels: ["Category A", "Category B"], innerPadding: 0.1 },
+      y: ["Category A", "Category B"],
     })
     .configureScales({
       x: { extents: { start: 0, end: 40 } },


### PR DESCRIPTION
An alternative implementation of https://github.com/mrc-ide/skadi-chart/pull/98, where I chose to make the inner padding configuration become part of the existing `configureCategories()` step, but this isn't necessarily the best choice. An alternative would be to pass it as part of the `configureAxes()` step, as in this PR.

See https://github.com/mrc-ide/skadi-chart/pull/98 for discussion of the merits/demerits of different interface ideas.

Copying note across from https://github.com/mrc-ide/skadi-chart/pull/98 for the historical record:
> The default padding should be > 0, so that ticks at the edges of bands do not get printed on top of each other. I chose 0.1 for the default value on both axes, which means '10% of band width'.