### PR TITLE
Tick configuration

### DIFF
--- a/src/Chart/config/Config.ts
+++ b/src/Chart/config/Config.ts
@@ -7,17 +7,21 @@ import {
   CurrOutput,
   CurrState,
   DefaultCurrFlags,
-  This
+  This,
+  TickArgs,
+  TickConfig,
 } from "./types";
 import { CurrFlags as PrevFlags, CurrOutput as PrevOutput } from "../data/types";
 import { Visual } from "../visual/Visual";
 import { categoricalChartTypes, processScaleArgs, ScaleArgs, ScaleArgsParsed, ScaleOutput } from "./scales";
 import { doXY, makeObjXY } from "@/helpers";
+import { defaultTickConfig } from "./ticks";
 
 export class Config<M, T extends ChartType, Flags extends CurrFlags> {
   private axes: AxisConfig = { x: { label: { text: "", padding: 50 } }, y: { label: { text: "", padding: 40 } } };
   private categories: Categories["categoricalXY"] = { x: [], y: [] };
   private scales: ScaleOutput[ChartType] | null = null;
+  private ticks: TickConfig[ChartType] | null = null;
 
   private constructor(private prevOutput: PrevOutput<M>) {};
 
@@ -72,6 +76,28 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
     return this as This<M, T, NewFlags>;
   };
 
+  configureTicks(tickArgs: TickArgs[T]) {
+    const defaultTickCfg = defaultTickConfig(this.prevOutput);
+    this.ticks = makeObjXY(axis => {
+      const args = tickArgs[axis];
+      const tickDefault = { ...defaultTickCfg[axis] };
+      if (!args) { return tickDefault; }
+
+      const numerical = { ...tickDefault.numerical, ...args.numerical };
+      if (numerical.enableMathJax && !numerical.formatter) {
+        throw new Error("When MathJax is enabled, a formatter must be provided.");
+      }
+      if ("categorical" in tickDefault) {
+        return {
+          numerical,
+          categorical: { ...tickDefault.categorical, ...("categorical" in args ? args.categorical : {}) },
+        }
+      }
+      return { numerical };
+    });
+    return this as This<M, T, Flags>;
+  }
+
   startVisual() {
     if (!this.scales) {
       throw new Error("Scales must be configured before going into startVisual")
@@ -80,11 +106,18 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
       axes: this.axes,
       categories: this.categories,
       scales: this.scales,
+      ticks: this.ticks ?? defaultTickConfig(this.prevOutput),
     };
     const output = {
       ...this.prevOutput,
       configState,
     } as CurrOutput<M>;
     return Visual.start<M, T, Flags>(output);
+  };
+
+  private getDefaultTickCount(size: number) {
+    if (size < 250) return 3;
+    if (size < 450) return 6;
+    return 10;
   };
 };

--- a/src/Chart/config/Config.ts
+++ b/src/Chart/config/Config.ts
@@ -15,6 +15,7 @@ import { Visual } from "../visual/Visual";
 import { categoricalChartTypes, processScaleArgs, ScaleArgs, ScaleArgsParsed, ScaleOutput } from "./scales";
 import { doXY, makeObjXY } from "@/helpers";
 import { defaultTickConfig } from "./ticks";
+import { deepAssignRecordIfDefined } from "./utils";
 
 export class Config<M, T extends ChartType, Flags extends CurrFlags> {
   private axes: AxisConfig["categoricalXY"] = {
@@ -35,28 +36,12 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
   };
 
   configureAxes(args: AxisArgs[T] = {}) {
-    doXY(axis => {
-      const axArgs = args[axis];
-      if (axArgs?.label) {
-        this.axes[axis].label.text = axArgs.label.text;
-        if (axArgs.label.padding !== undefined) {
-          this.axes[axis].label.padding = axArgs.label.padding;
-        }
-      }
-      if (axArgs && "innerPadding" in axArgs && axArgs.innerPadding !== undefined) {
-        this.axes[axis].innerPadding = axArgs.innerPadding;
-      }
-    });
+    deepAssignRecordIfDefined(this.axes, args);
     return this as This<M, T, Flags>;
   }
 
   configureCategories(args: Categories[T]) {
-    if ("x" in args && args.x.length > 0) {
-      this.categories.x = args.x;
-    }
-    if ("y" in args && args.y.length > 0) {
-      this.categories.y = args.y;
-    }
+    deepAssignRecordIfDefined(this.categories, args);
     type NewFlags = MixNewFlags<CurrFlags, Flags, { hasConfiguredCategories: true }>
     return this as This<M, T, NewFlags>;
   };
@@ -69,37 +54,19 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
     });
     const scaleArgsParsed: ScaleArgsParsed =
       makeObjXY(() => ({ extents: { start: "auto", end: "auto" } }));
-    doXY(axis => {
-      if (scaleArgs && scaleArgs[axis]?.extents?.start) {
-        scaleArgsParsed[axis].extents.start = scaleArgs[axis].extents.start;
-      }
-      if (scaleArgs && scaleArgs[axis]?.extents?.end) {
-        scaleArgsParsed[axis].extents.end = scaleArgs[axis].extents.end;
-      }
-    });
+    deepAssignRecordIfDefined(scaleArgsParsed, scaleArgs);
     this.scales = processScaleArgs(scaleArgsParsed, this.prevOutput, this.categories, this.axes);
     type NewFlags = MixNewFlags<CurrFlags, Flags, { hasConfiguredScale: true }>
     return this as This<M, T, NewFlags>;
   };
 
   configureTicks(tickArgs: TickArgs[T]) {
-    const defaultTickCfg = defaultTickConfig(this.prevOutput);
-    this.ticks = makeObjXY(axis => {
-      const args = tickArgs[axis];
-      const tickDefault = { ...defaultTickCfg[axis] };
-      if (!args) { return tickDefault; }
-
-      const numerical = { ...tickDefault.numerical, ...args.numerical };
-      if (numerical.enableMathJax && !numerical.formatter) {
+    this.ticks ??= defaultTickConfig(this.prevOutput);
+    deepAssignRecordIfDefined(this.ticks, tickArgs);
+    doXY((axis) => {
+      if (this.ticks?.[axis].numerical.enableMathJax && !this.ticks?.[axis].numerical.formatter) {
         throw new Error("When MathJax is enabled, a formatter must be provided.");
       }
-      if ("categorical" in tickDefault) {
-        return {
-          numerical,
-          categorical: { ...tickDefault.categorical, ...("categorical" in args ? args.categorical : {}) },
-        }
-      }
-      return { numerical };
     });
     return this as This<M, T, Flags>;
   }

--- a/src/Chart/config/Config.ts
+++ b/src/Chart/config/Config.ts
@@ -120,10 +120,4 @@ export class Config<M, T extends ChartType, Flags extends CurrFlags> {
     } as CurrOutput<M>;
     return Visual.start<M, T, Flags>(output);
   };
-
-  private getDefaultTickCount(size: number) {
-    if (size < 250) return 3;
-    if (size < 450) return 6;
-    return 10;
-  };
 };

--- a/src/Chart/config/ticks.ts
+++ b/src/Chart/config/ticks.ts
@@ -2,7 +2,7 @@ import { PerAxisConfigByChartType } from "./types";
 import { CurrOutput as PrevOutput } from "../data/types";
 import { categoricalChartTypes } from "./scales";
 import { makeObjXY } from "@/helpers";
-import { ChartType, DeepPartial } from "@/types";
+import { ChartType, DeepPartialRecord } from "@/types";
 
 const defaultNumericalSpecifier = ".2~s"; // an SI-prefix with 2 significant figures and no trailing zeros, 42e6 -> 42M
 
@@ -20,8 +20,8 @@ export type TickConfigDefault = { numerical: TickConfigBase<number> }
 type TickConfigCategorical = TickConfigDefault & { categorical: TickConfigBase<string> }
 export type TickConfig = PerAxisConfigByChartType<TickConfigDefault, TickConfigCategorical>
 
-type TickArgsDefault = DeepPartial<TickConfigDefault>
-type TickArgsCategorical = DeepPartial<TickConfigCategorical>
+type TickArgsDefault = DeepPartialRecord<TickConfigDefault>
+type TickArgsCategorical = DeepPartialRecord<TickConfigCategorical>
 export type TickArgs = PerAxisConfigByChartType<TickArgsDefault, TickArgsCategorical, "optional">
 
 export const defaultTickConfig = <M>(prevOutput: PrevOutput<M>): TickConfig[ChartType] => {

--- a/src/Chart/config/ticks.ts
+++ b/src/Chart/config/ticks.ts
@@ -1,0 +1,35 @@
+import { TickConfig } from "./types";
+import { CurrOutput as PrevOutput } from "../data/types";
+import { categoricalChartTypes } from "./scales";
+import { makeObjXY } from "@/helpers";
+import { ChartType } from "@/types";
+
+const defaultNumericalSpecifier = ".2~s"; // an SI-prefix with 2 significant figures and no trailing zeros, 42e6 -> 42M
+
+export const defaultTickConfig = <M>(prevOutput: PrevOutput<M>): TickConfig[ChartType] => {
+  const { bounds } = prevOutput.baseState;
+  return makeObjXY(axis => {
+    const hasCategoricalAxis = categoricalChartTypes[axis].includes(prevOutput.chartType);
+    return {
+      numerical: {
+        padding: hasCategoricalAxis ? 6 : 12,
+        size: 0,
+        count: getDefaultTickCount(axis === "x" ? bounds.width : bounds.height),
+        specifier: defaultNumericalSpecifier,
+        enableMathJax: false,
+      },
+      ...(hasCategoricalAxis ? {
+        categorical: {
+          padding: 30,
+          size: 0,
+        },
+      } : {}),
+    };
+  });
+}
+
+const getDefaultTickCount = (size: number) => {
+  if (size < 250) return 3;
+  if (size < 450) return 6;
+  return 10;
+};

--- a/src/Chart/config/ticks.ts
+++ b/src/Chart/config/ticks.ts
@@ -2,7 +2,7 @@ import { PerAxisConfigByChartType } from "./types";
 import { CurrOutput as PrevOutput } from "../data/types";
 import { categoricalChartTypes } from "./scales";
 import { makeObjXY } from "@/helpers";
-import { ChartType } from "@/types";
+import { ChartType, DeepPartial } from "@/types";
 
 const defaultNumericalSpecifier = ".2~s"; // an SI-prefix with 2 significant figures and no trailing zeros, 42e6 -> 42M
 
@@ -20,9 +20,8 @@ export type TickConfigDefault = { numerical: TickConfigBase<number> }
 type TickConfigCategorical = TickConfigDefault & { categorical: TickConfigBase<string> }
 export type TickConfig = PerAxisConfigByChartType<TickConfigDefault, TickConfigCategorical>
 
-type TickArgsBase<Domain> = Partial<TickConfigBase<Domain>>
-type TickArgsDefault = { numerical?: TickArgsBase<number> }
-type TickArgsCategorical = TickArgsDefault & { categorical?: TickArgsBase<string> }
+type TickArgsDefault = DeepPartial<TickConfigDefault>
+type TickArgsCategorical = DeepPartial<TickConfigCategorical>
 export type TickArgs = PerAxisConfigByChartType<TickArgsDefault, TickArgsCategorical, "optional">
 
 export const defaultTickConfig = <M>(prevOutput: PrevOutput<M>): TickConfig[ChartType] => {

--- a/src/Chart/config/types.ts
+++ b/src/Chart/config/types.ts
@@ -41,22 +41,23 @@ export type This<M, T extends ChartType, Flags extends CurrFlags> =
   Omit<Config<M, T, Flags>, MethodsToRemove<T, Flags>>
 
 type AxisKeyMode = "required" | "optional"
+type MaybePartial<T, Mode extends AxisKeyMode> = Mode extends "optional" ? Partial<T> : T
 // When the per-axis type is never, that axis must be omitted.
 type XYOmitNever<X, Y, Mode extends AxisKeyMode> =
-  ([X] extends [never] ? {} : Mode extends "optional" ? Partial<{ x: X }> : { x: X })
-  & ([Y] extends [never] ? {} : Mode extends "optional" ? Partial<{ y: Y }> : { y: Y })
+  ([X] extends [never] ? {} : MaybePartial<{ x: X }, Mode>)
+  & ([Y] extends [never] ? {} : MaybePartial<{ y: Y }, Mode>)
 
 // In 'optional' mode, each axis can be omitted (if it isn't already omitted by XYOmitNever).
 export type PerAxisConfigByChartType<
   Default,
   Categorical,
   Mode extends AxisKeyMode = "required",
-> = {
+> = HasAllKeys<ChartType, {
   default: XYOmitNever<Default, Default, Mode>,
   categoricalX: XYOmitNever<Categorical, Default, Mode>,
   categoricalY: XYOmitNever<Default, Categorical, Mode>,
   categoricalXY: XYOmitNever<Categorical, Categorical, Mode>,
-};
+}>
 
 
 export type Categories = PerAxisConfigByChartType<never, string[]>

--- a/src/Chart/config/types.ts
+++ b/src/Chart/config/types.ts
@@ -40,13 +40,24 @@ export type This<M, T extends ChartType, Flags extends CurrFlags> =
   Omit<Config<M, T, Flags>, MethodsToRemove<T, Flags>>
 
 
+type AxisTypesByChartType<
+  Default,
+  Categorical,
+  AxisKeyMode extends "required" | "optional" = "required"
+> = HasAllKeys<ChartType, {
+  default: Default extends never ? never : XY<Default>,
+  categoricalX: { x: Categorical, y: Default },
+  categoricalY: { x: Default, y: Categorical },
+  categoricalXY: Categorical extends never ? never : XY<Categorical>,
+} extends infer Types ? {
+  [T in keyof Types]: AxisKeyMode extends "optional"
+    ? Partial<Types[T]> // In 'optional' mode, each axis can be omitted.
+    : Types[T]
+} : never>
 
-export type Categories = HasAllKeys<ChartType, {
-  default: never,
-  categoricalX: { x: string[] },
-  categoricalY: { y: string[] },
-  categoricalXY: { x: string[], y: string[] },
-}>
+
+export type Categories = AxisTypesByChartType<never, string[]>
+
 
 export type AxisArgs = Partial<XY<{
   label?: {

--- a/src/Chart/config/types.ts
+++ b/src/Chart/config/types.ts
@@ -1,4 +1,4 @@
-import { CategoricalChartType, ChartType, HasAllKeys, Prettify, XY } from "@/types"
+import { CategoricalChartType, ChartType, HasAllKeys, Prettify, XorY, XY } from "@/types"
 import { Config } from "./Config"
 import { CurrFlags as PrevFlags, CurrOutputs as PrevOutputs } from "../data/types"
 import { ScaleOutput } from "./scales"
@@ -39,24 +39,28 @@ type MethodsToRemove<T extends ChartType, Flags extends CurrFlags> =
 export type This<M, T extends ChartType, Flags extends CurrFlags> =
   Omit<Config<M, T, Flags>, MethodsToRemove<T, Flags>>
 
+// When the per-axis type is never, that axis must be omitted.
+type XYOmitNever<X, Y> =
+  ([X] extends [never] ? {} : { x: X })
+  & ([Y] extends [never] ? {} : { y: Y })
 
-type AxisTypesByChartType<
+type PerAxisConfigByChartType<
   Default,
   Categorical,
   AxisKeyMode extends "required" | "optional" = "required"
 > = HasAllKeys<ChartType, {
-  default: Default extends never ? never : XY<Default>,
-  categoricalX: { x: Categorical, y: Default },
-  categoricalY: { x: Default, y: Categorical },
-  categoricalXY: Categorical extends never ? never : XY<Categorical>,
+  default: XYOmitNever<Default, Default>,
+  categoricalX: XYOmitNever<Categorical, Default>,
+  categoricalY: XYOmitNever<Default, Categorical>,
+  categoricalXY: XYOmitNever<Categorical, Categorical>,
 } extends infer Types ? {
   [T in keyof Types]: AxisKeyMode extends "optional"
-    ? Partial<Types[T]> // In 'optional' mode, each axis can be omitted.
+    ? Partial<Types[T]> // In 'optional' mode, each axis can be omitted (if it isn't already omitted by XYOmitNever).
     : Types[T]
 } : never>
 
 
-export type Categories = AxisTypesByChartType<never, string[]>
+export type Categories = PerAxisConfigByChartType<never, string[]>
 
 
 export type AxisArgs = Partial<XY<{
@@ -72,29 +76,31 @@ export type AxisConfig = XY<{
   }
 }>;
 
-type TickConfigBase<Domain> = {
+export type TickFormatter<Domain> = (value: Domain, index: number) => string
+export type TickConfigBase<Domain> = {
   padding: number,
   size: number,
-  formatter?: (value: Domain, index: number) => string,
+  formatter?: TickFormatter<Domain> 
 } & (Domain extends number ? {
   count: number,
   specifier: string,
   enableMathJax: boolean,
 } : {})
-export type TickConfigCategorical = { categorical: TickConfigBase<string> }
-export type TickConfigDefault = { numerical: TickConfigBase<number> } & TickConfigCategorical
-export type TickConfig = AxisTypesByChartType<TickConfigDefault, TickConfigCategorical>
+export type TickConfigDefault = { numerical: TickConfigBase<number> }
+type TickConfigCategorical = TickConfigDefault & { categorical: TickConfigBase<string> }
+export type TickConfig = PerAxisConfigByChartType<TickConfigDefault, TickConfigCategorical>
 
 type TickArgsBase<Domain> = Partial<TickConfigBase<Domain>>
-export type TickArgsCategorical = { categorical?: TickArgsBase<string> }
-export type TickArgsDefault = { numerical?: TickArgsBase<number> } & TickArgsCategorical
-export type TickArgs = AxisTypesByChartType<TickArgsDefault, TickArgsCategorical, "optional">
+type TickArgsDefault = { numerical?: TickArgsBase<number> }
+type TickArgsCategorical = TickArgsDefault & { categorical?: TickArgsBase<string> }
+export type TickArgs = PerAxisConfigByChartType<TickArgsDefault, TickArgsCategorical, "optional">
 
 
 export type CurrState<T extends ChartType> = {
   axes: AxisConfig,
   categories: Categories[T],
   scales: ScaleOutput[T],
+  ticks: TickConfig[T],
 }
 
 export type CurrOutputs<M> = {

--- a/src/Chart/config/types.ts
+++ b/src/Chart/config/types.ts
@@ -40,25 +40,23 @@ type MethodsToRemove<T extends ChartType, Flags extends CurrFlags> =
 export type This<M, T extends ChartType, Flags extends CurrFlags> =
   Omit<Config<M, T, Flags>, MethodsToRemove<T, Flags>>
 
+type AxisKeyMode = "required" | "optional"
 // When the per-axis type is never, that axis must be omitted.
-type XYOmitNever<X, Y> =
-  ([X] extends [never] ? {} : { x: X })
-  & ([Y] extends [never] ? {} : { y: Y })
+type XYOmitNever<X, Y, Mode extends AxisKeyMode> =
+  ([X] extends [never] ? {} : Mode extends "optional" ? Partial<{ x: X }> : { x: X })
+  & ([Y] extends [never] ? {} : Mode extends "optional" ? Partial<{ y: Y }> : { y: Y })
 
+// In 'optional' mode, each axis can be omitted (if it isn't already omitted by XYOmitNever).
 export type PerAxisConfigByChartType<
   Default,
   Categorical,
-  AxisKeyMode extends "required" | "optional" = "required"
-> = HasAllKeys<ChartType, {
-  default: XYOmitNever<Default, Default>,
-  categoricalX: XYOmitNever<Categorical, Default>,
-  categoricalY: XYOmitNever<Default, Categorical>,
-  categoricalXY: XYOmitNever<Categorical, Categorical>,
-} extends infer Types ? {
-  [T in keyof Types]: AxisKeyMode extends "optional"
-    ? Partial<Types[T]> // In 'optional' mode, each axis can be omitted (if it isn't already omitted by XYOmitNever).
-    : Types[T]
-} : never>
+  Mode extends AxisKeyMode = "required",
+> = {
+  default: XYOmitNever<Default, Default, Mode>,
+  categoricalX: XYOmitNever<Categorical, Default, Mode>,
+  categoricalY: XYOmitNever<Default, Categorical, Mode>,
+  categoricalXY: XYOmitNever<Categorical, Categorical, Mode>,
+};
 
 
 export type Categories = PerAxisConfigByChartType<never, string[]>

--- a/src/Chart/config/types.ts
+++ b/src/Chart/config/types.ts
@@ -64,9 +64,9 @@ export type PerAxisConfigByChartType<
 export type Categories = PerAxisConfigByChartType<never, string[]>
 
 
-type AxisArgsBase = { label?: { text: string, padding?: number } }
-type AxisArgsCategorical = AxisArgsBase & { innerPadding?: number }
-export type AxisArgs = PerAxisConfigByChartType<AxisArgsBase, AxisArgsCategorical, "optional">
+type AxisArgsNumerical = { label?: { text: string, padding?: number } }
+type AxisArgsCategorical = AxisArgsNumerical & { innerPadding?: number }
+export type AxisArgs = PerAxisConfigByChartType<AxisArgsNumerical, AxisArgsCategorical, "optional">
 
 type AxisConfigNumerical = { label: { text: string, padding: number } }
 type AxisConfigCategorical = AxisConfigNumerical & { innerPadding: number }

--- a/src/Chart/config/types.ts
+++ b/src/Chart/config/types.ts
@@ -72,6 +72,23 @@ export type AxisConfig = XY<{
   }
 }>;
 
+type TickConfigBase<Domain> = {
+  padding: number,
+  size: number,
+  formatter?: (value: Domain, index: number) => string,
+} & (Domain extends number ? {
+  count: number,
+  specifier: string,
+  enableMathJax: boolean,
+} : {})
+export type TickConfigCategorical = { categorical: TickConfigBase<string> }
+export type TickConfigDefault = { numerical: TickConfigBase<number> } & TickConfigCategorical
+export type TickConfig = AxisTypesByChartType<TickConfigDefault, TickConfigCategorical>
+
+type TickArgsBase<Domain> = Partial<TickConfigBase<Domain>>
+export type TickArgsCategorical = { categorical?: TickArgsBase<string> }
+export type TickArgsDefault = { numerical?: TickArgsBase<number> } & TickArgsCategorical
+export type TickArgs = AxisTypesByChartType<TickArgsDefault, TickArgsCategorical, "optional">
 
 
 export type CurrState<T extends ChartType> = {

--- a/src/Chart/config/utils.ts
+++ b/src/Chart/config/utils.ts
@@ -1,0 +1,33 @@
+import { DeepPartialRecord } from "@/types";
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  !!v
+  && typeof v === "object"
+  && (Object.getPrototypeOf(v) === Object.prototype || Object.getPrototypeOf(v) === null);
+
+const assignIfDefined = <
+  Obj extends Record<string, unknown>,
+  K extends keyof Obj
+>(obj: Obj,
+  k: K,
+  v: Obj[K] | undefined,
+) => {
+  obj[k] = v === undefined ? obj[k] : v;
+}
+
+export const deepAssignRecordIfDefined = <Obj extends Record<string, unknown>>(
+  obj1: Obj,
+  obj2: DeepPartialRecord<Obj>,
+) => {
+  for (const k of Object.keys(obj2) as Array<keyof Obj>) {
+    const v1 = obj1[k];
+    const v2 = obj2[k];
+
+    if (isPlainObject(v2)) {
+      deepAssignRecordIfDefined<Record<string, unknown>>(v1 as Record<string, unknown>, v2);
+      assignIfDefined(obj1, k, v1);
+    } else {
+      assignIfDefined(obj1, k, v2);
+    }
+  }
+}

--- a/src/Chart/visual/layers/AxesLayer.ts
+++ b/src/Chart/visual/layers/AxesLayer.ts
@@ -1,13 +1,14 @@
 import * as d3 from "@/d3";
 import { Layer } from "./Layer";
-import { ScaleNumeric, XorY } from "@/types";
-import { CurrOutput as PrevOutput } from "@/Chart/config/types";
+import { Point, ScaleNumeric, XorY } from "@/types";
+import { CurrOutput as PrevOutput, TickConfigBase, TickFormatter } from "@/Chart/config/types";
 import { CoreLayer, CoreLayers, VisualLayer } from "../types";
 import { ScaleCategorical } from "@/Chart/config/scales";
 import { getInner } from "@/Chart/base/utils";
 import { doXY } from "@/helpers";
 
 const animationDuration = 350;
+declare const MathJax: any;
 
 export class AxesLayer<M> extends Layer<M, null> {
   private zoomCallbacks: (() => Promise<void>)[] = [];
@@ -25,31 +26,52 @@ export class AxesLayer<M> extends Layer<M, null> {
 
   draw = () => {
     if (this.prevOutput.chartType === "default") {
-      this.drawNumerical("x", this.prevOutput.configState.scales.x, true);
-      this.drawNumerical("y", this.prevOutput.configState.scales.y, true);
+      this.drawNumerical("x", this.prevOutput.configState.scales.x, this.prevOutput.configState.ticks.x.numerical, true);
+      this.drawNumerical("y", this.prevOutput.configState.scales.y, this.prevOutput.configState.ticks.y.numerical, true);
     } else if (this.prevOutput.chartType === "categoricalX") {
-      this.drawCategorical("x", this.prevOutput.configState.scales.x);
-      this.drawNumerical("y", this.prevOutput.configState.scales.y, true);
+      this.drawCategorical("x", this.prevOutput.configState.scales.x, this.prevOutput.configState.ticks.x);
+      this.drawNumerical("y", this.prevOutput.configState.scales.y, this.prevOutput.configState.ticks.y.numerical, true);
     } else if (this.prevOutput.chartType === "categoricalY") {
-      this.drawNumerical("x", this.prevOutput.configState.scales.x, true);
-      this.drawCategorical("y", this.prevOutput.configState.scales.y);
+      this.drawNumerical("x", this.prevOutput.configState.scales.x, this.prevOutput.configState.ticks.x.numerical, true);
+      this.drawCategorical("y", this.prevOutput.configState.scales.y, this.prevOutput.configState.ticks.y);
     } else {
-      this.drawCategorical("x", this.prevOutput.configState.scales.x);
-      this.drawCategorical("y", this.prevOutput.configState.scales.y);
+      this.drawCategorical("x", this.prevOutput.configState.scales.x, this.prevOutput.configState.ticks.x);
+      this.drawCategorical("y", this.prevOutput.configState.scales.y, this.prevOutput.configState.ticks.y);
     }
 
     this.addLabels();
   };
 
-  private drawNumerical = (axis: XorY, scale: ScaleNumeric, addZoom: boolean) => {
+  private drawNumerical = (
+    axis: XorY,
+    scale: ScaleNumeric,
+    tickConfig: TickConfigBase<number>,
+    addZoom: boolean,
+  ) => {
     const { getHtmlId, bounds } = this.prevOutput.baseState;
+    const { formatter: tickFormatter } = tickConfig;
     const inner = getInner(bounds);
     const translation = axis === "x"
       ? { x: 0, y: inner.y.end }
       : { x: inner.x.start, y: 0 };
     const axisConstructor = axis === "x" ? d3.axisBottom : d3.axisLeft;
 
-    const numericalAxis = axisConstructor(scale);
+    const numericalAxis = axisConstructor(scale)
+      .ticks(tickConfig.count, tickConfig.specifier)
+      .tickSize(tickConfig.size)
+      .tickPadding(tickConfig.padding);
+    if (tickFormatter) {
+      if (tickConfig.enableMathJax) {
+        // When MathJax is enabled, blank out the default text labels here.
+        // the MathJax-rendered labels are drawn separately below, as foreignObject elements.
+        numericalAxis.tickFormat(() => "");
+      } else {
+        numericalAxis.tickFormat((val: d3.NumberValue, i) => tickFormatter(val as number, i));
+      }
+      // When d3-axis' .tickFormat is left uncalled, d3-axis falls back to its own built-in default
+      // formatter which makes use of the specifier option.
+    }
+
     const axisGElement = this.coreLayers[CoreLayer.Svg]
       .append("g")
       .attr("id", `${axis}-${getHtmlId(VisualLayer.Axes)}`)
@@ -57,6 +79,10 @@ export class AxesLayer<M> extends Layer<M, null> {
       .attr("transform", `translate(${translation.x},${translation.y})`)
       .call(numericalAxis);
     axisGElement.select(".domain").style("stroke-opacity", 0);
+
+    if (tickFormatter && tickConfig.enableMathJax) {
+      this.drawMathJaxTicks(scale, tickConfig, tickFormatter, axisGElement);
+    }
 
     if (addZoom) {
       const zoom = async () => {
@@ -69,16 +95,25 @@ export class AxesLayer<M> extends Layer<M, null> {
     }
   };
 
-  private drawCategorical = (axis: XorY, { scale, categories }: ScaleCategorical) => {
+  private drawCategorical = (
+    axis: XorY,
+    { scale, categories }: ScaleCategorical,
+    tickConfig: { categorical: TickConfigBase<string>, numerical: TickConfigBase<number> },
+  ) => {
     const { getHtmlId, bounds } = this.prevOutput.baseState;
+    const { formatter } = tickConfig.categorical;
     const inner = getInner(bounds);
     const translation = axis === "x"
       ? { x: 0, y: inner.y.end }
       : { x: inner.x.start, y: 0 };
     const axisConstructor = axis === "x" ? d3.axisBottom : d3.axisLeft;
-    const tickPadding = 30; // This will become a configurable option.
     
-    const categoricalAxis = axisConstructor(scale).tickPadding(tickPadding);
+    const categoricalAxis = axisConstructor(scale)
+      .tickSize(tickConfig.categorical.size)
+      .tickPadding(tickConfig.categorical.padding);
+    if (formatter) {
+      categoricalAxis.tickFormat(formatter);
+    }
     const axisGElement = this.coreLayers[CoreLayer.Svg]
       .append("g")
       .attr("id", `${axis}-categorical-${getHtmlId(VisualLayer.Axes)}`)
@@ -88,9 +123,42 @@ export class AxesLayer<M> extends Layer<M, null> {
     axisGElement.select(".domain").style("stroke-opacity", 0);
 
     Object.entries(categories).forEach(([_, categoryScale]) => {
-      this.drawNumerical(axis, categoryScale, false);
+      this.drawNumerical(axis, categoryScale, tickConfig.numerical, false);
     });
   };
+
+  private drawMathJaxTicks = (
+    scale: ScaleNumeric,
+    tickConfig: TickConfigBase<number>,
+    tickFormatter: TickFormatter<number>,
+    axisGElement: d3.Selection<SVGGElement, Point, null, undefined>,
+  ) => {
+    console.warn(
+      "enableMathJax is currently not compatible with zoom layer" +
+      " and is only available for the x axis"
+    );
+    axisGElement
+      .selectAll("g")
+      .data(scale.ticks(tickConfig.count))
+      .append("foreignObject")
+      .attr("width", 50)
+      .attr("height", 50)
+      .attr("x", 0)
+      .attr("y", tickConfig.padding)
+      .append("xhtml:span")
+      .attr("class", "tick-mathjax")
+      .text((d, i) => tickFormatter(d, i));
+    MathJax.typesetPromise().then(() => {
+      const spanNodes = this.coreLayers[CoreLayer.Svg]
+        .selectAll("span.tick-mathjax")
+        .nodes() as HTMLSpanElement[];
+      spanNodes.forEach(sn => {
+        const { width } = sn.getBoundingClientRect();
+        const foreignObject = sn.parentElement! as unknown as SVGForeignObjectElement;
+        foreignObject.x.baseVal.value = - width / 2;
+      });
+    });
+  }
 
   private addLabels = () => {
     const { getHtmlId, bounds } = this.prevOutput.baseState;

--- a/src/demo/NewSkadiChart.vue
+++ b/src/demo/NewSkadiChart.vue
@@ -102,6 +102,10 @@ const renderChart = (chartType: ChartType) => {
         x: { extents: { start: 0, end: 40 } },
         y: { extents: { start: -500, end: 500 } },
       })
+      .configureTicks({
+        x: { numerical: { formatter: (num) => `$${num}^{1}$`, enableMathJax: true } },
+        y: { numerical: { specifier: ".1f", padding: 2, size: 5, count: 20 } },
+      })
       .startVisual()
       .addAxes()
       .startInteractive()
@@ -125,6 +129,15 @@ const renderChart = (chartType: ChartType) => {
         x: { extents: { start: -20, end: 20 } },
         y: { extents: { start: -500, end: 500 } },
       })
+      .configureTicks({
+        x: {
+          categorical: { formatter: (v) => v.toLowerCase() },
+          numerical: { count: 3 }
+        },
+        y: {
+          categorical: { formatter: (v) => v.toUpperCase(), padding: 40 },
+        },
+      })
       .startVisual()
       .addAxes()
       .startInteractive()
@@ -146,6 +159,9 @@ const renderChart = (chartType: ChartType) => {
       .configureScales({
         x: { extents: { start: 0, end: 40 } },
         y: { extents: { start: -500, end: 500 } },
+      })
+      .configureTicks({
+        x: { numerical: { count: 2 } },
       })
       .startVisual()
       .addAxes()

--- a/src/demo/NewSkadiChart.vue
+++ b/src/demo/NewSkadiChart.vue
@@ -29,6 +29,10 @@
       <div class="chart" ref="categoricalYAxis" id="categoricalYAxis"></div>
     </div>
   </div>
+  <h1 style="margin-top: 100px">
+    With MathJax (experimental)
+  </h1>
+  <div class="chart" ref="chartMathJax" id="chartMathJax"></div>
 </template>
 
 <style scoped>
@@ -62,6 +66,7 @@ const numericalAxes = ref<HTMLDivElement | null>(null);
 const categoricalXYAxes = ref<HTMLDivElement | null>(null);
 const categoricalXAxis = ref<HTMLDivElement | null>(null);
 const categoricalYAxis = ref<HTMLDivElement | null>(null);
+const chartMathJax = ref<HTMLDivElement | null>(null);
 
 const chartTypes: readonly ChartType[] = [
   "default",
@@ -83,6 +88,32 @@ const chartContainers: Record<ChartType, typeof numericalAxes> = {
   categoricalY: categoricalYAxis,
 };
 
+const renderMathJaxChart = () => {
+  const container = chartMathJax.value;
+  if (!container) {
+    return;
+  }
+  new ChartNew("default", container)
+    .startData()
+    .startConfig()
+    .configureAxes({
+      x: { label: { text: "Time" } },
+      y: { label: { text: "Value" } },
+    })
+    .configureScales({
+      x: { extents: { start: 0, end: 40 } },
+      y: { extents: { start: -500, end: 500 } },
+    })
+    .configureTicks({
+      x: { numerical: { formatter: (num) => `$${num}^{1}$`, enableMathJax: true } },
+      y: { numerical: { specifier: ".1f", padding: 2, size: 5, count: 20 } },
+    })
+    .startVisual()
+    .addAxes()
+    .startInteractive()
+    .end();
+}
+
 const renderChart = (chartType: ChartType) => {
   const container = chartContainers[chartType].value;
 
@@ -103,7 +134,6 @@ const renderChart = (chartType: ChartType) => {
         y: { extents: { start: -500, end: 500 } },
       })
       .configureTicks({
-        x: { numerical: { formatter: (num) => `$${num}^{1}$`, enableMathJax: true } },
         y: { numerical: { specifier: ".1f", padding: 2, size: 5, count: 20 } },
       })
       .startVisual()
@@ -111,9 +141,7 @@ const renderChart = (chartType: ChartType) => {
       .startInteractive()
       .end();
     return;
-  }
-
-  if (chartType === "categoricalXY") {
+  } else if (chartType === "categoricalXY") {
     new ChartNew("categoricalXY", container)
       .startData()
       .startConfig()
@@ -143,9 +171,7 @@ const renderChart = (chartType: ChartType) => {
       .startInteractive()
       .end();
     return;
-  }
-
-  if (chartType === "categoricalX") {
+  } else if (chartType === "categoricalX") {
     new ChartNew("categoricalX", container)
       .startData()
       .startConfig()
@@ -196,5 +222,7 @@ watch(selectedChartTypes, (newChartTypes) => {
 
 onMounted(() => {
   selectedChartTypes.value.forEach(renderChart);
+
+  renderMathJaxChart();
 });
 </script>

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,13 @@ export type HasAllKeys<
 > = T
 
 
+export type DeepPartial<T> =
+  T extends Function
+    ? T
+    : T extends object ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    } : T;
+
 
 type EmptyExtensions = { [K in ChartType]: {} }
 type Category<Key extends XorY> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,14 +20,13 @@ export type HasAllKeys<
   T extends Record<Keys, any>
 > = T
 
-
-export type DeepPartial<T> =
-  T extends Function
-    ? T
-    : T extends object ? {
-      [P in keyof T]?: DeepPartial<T[P]>;
-    } : T;
-
+export type DeepPartialRecord<T extends Record<string, unknown>> = {
+  [K in keyof T]?: T[K] extends Function
+    ? T[K]
+    : T[K] extends Record<string, unknown>
+      ? DeepPartialRecord<T[K]>
+      : T[K];
+};
 
 type EmptyExtensions = { [K in ChartType]: {} }
 type Category<Key extends XorY> = {

--- a/tests/e2e/chart.spec.ts
+++ b/tests/e2e/chart.spec.ts
@@ -127,8 +127,8 @@ test("chart with categorical x and y axes", async ({ page }) => {
       y: "Y Category",
     })
     .expectTicks({
-      x: { categorical: true, text: ["A", "B", "C"] },
-      y: { categorical: true, text: ["Category A", "Category B"] },
+      x: { categorical: true, text: ["a", "b", "c"] },
+      y: { categorical: true, text: ["CATEGORY A", "CATEGORY B"] },
     })
     .end();
 });

--- a/tests/unit/config-utils.test.ts
+++ b/tests/unit/config-utils.test.ts
@@ -1,0 +1,97 @@
+import { deepAssignRecordIfDefined } from "@/Chart/config/utils";
+import { DeepPartialRecord } from "@/types";
+
+describe("config utils", () => {
+  describe("deepAssignRecordIfDefined", () => {
+    test("assigns shallow defined values and skips undefined", () => {
+      const target = { a: 1, b: "keep" };
+      const patch: DeepPartialRecord<typeof target> = { a: 9, b: undefined };
+
+      deepAssignRecordIfDefined(target, patch);
+
+      expect(target).toStrictEqual({ a: 9, b: "keep" });
+    });
+
+    test("deep merges nested plain objects", () => {
+      const target = {
+        title: "chart",
+        axis: {
+          x: { min: 0, max: 10 },
+          y: { min: 1, max: 20 },
+        },
+      };
+
+      const patch: DeepPartialRecord<typeof target> = {
+        axis: {
+          x: { min: 2 },
+        },
+      };
+
+      deepAssignRecordIfDefined(target, patch);
+
+      expect(target).toStrictEqual({
+        title: "chart",
+        axis: {
+          x: { min: 2, max: 10 },
+          y: { min: 1, max: 20 },
+        },
+      });
+    });
+
+    test("does not deep merge arrays", () => {
+      const target = {
+        points: [1, 2, 3],
+        nested: { points: [4, 5] },
+      };
+
+      const patch: DeepPartialRecord<typeof target> = {
+        points: [10],
+        nested: { points: [99] },
+      };
+
+      deepAssignRecordIfDefined(target, patch);
+
+      expect(target).toStrictEqual({
+        points: [10],
+        nested: { points: [99] },
+      });
+    });
+
+    test("does not deep merge non-plain objects", () => {
+      const target = {
+        date: new Date("2020-01-01T00:00:00.000Z"),
+        map: new Map([["a", 1]]),
+      };
+
+      const patch: DeepPartialRecord<typeof target> = {
+        date: new Date("2021-01-01T00:00:00.000Z"),
+        map: new Map([["b", 2]]),
+      };
+
+      deepAssignRecordIfDefined(target, patch);
+
+      expect(target.date.toISOString()).toBe("2021-01-01T00:00:00.000Z");
+      expect(Array.from(target.map.entries())).toStrictEqual([["b", 2]]);
+    });
+
+    test("deep merges null-prototype dictionaries", () => {
+      const base = Object.create(null) as Record<string, unknown>;
+      base.a = 1;
+
+      const patch = Object.create(null) as Record<string, unknown>;
+      patch.b = 2;
+
+      const target: Record<string, unknown> = {
+        nested: base,
+      };
+
+      deepAssignRecordIfDefined(target, {
+        nested: patch,
+      });
+
+      expect((target.nested as Record<string, unknown>).a).toBe(1);
+      expect((target.nested as Record<string, unknown>).b).toBe(2);
+      expect(Object.getPrototypeOf(target.nested)).toBe(null);
+    });
+  });
+});


### PR DESCRIPTION
Adds configuration for ticks, including MathJax.

The default tick configuration has to be returned from a function in this case, rather than something we can define up-front as a private property on Config as with axes and categories configuration, because it has a dependency on a prevOutput value, which is not known at the time of initializing Config.

## Type helpers

The most interesting change here is the new type helpers in `src/Chart/config/types.ts`. We had established a pattern of defining 1 or 2 kinds of type signatures per configuration function, per axis, per chart type.

For example, for configureCategories, we previously had this one:

```ts
export type Categories = HasAllKeys<ChartType, {
  default: never,
  categoricalX: { x: string[] },
  categoricalY: { y: string[] },
  categoricalXY: { x: string[], y: string[] },
}>
```

And for configureAxes, we had two types, for args and config:

```ts
export type AxisArgs = HasAllKeys<ChartType, {
  default: Partial<XY<AxisArgsBase>>,
  categoricalX: Partial<{ x: AxisArgsCategorical } & { y: AxisArgsBase }>,
  categoricalY: Partial<{ x: AxisArgsBase } & { y: AxisArgsCategorical }>,
  categoricalXY: Partial<{ x: AxisArgsCategorical } & { y: AxisArgsCategorical }>,
}>

export type AxisConfig = HasAllKeys<ChartType, {
  default: XY<AxisConfigNumerical>,
  categoricalX: { x: AxisConfigCategorical } & { y: AxisConfigNumerical },
  categoricalY: { x: AxisConfigNumerical } & { y: AxisConfigCategorical },
  categoricalXY: { x: AxisConfigCategorical } & { y: AxisConfigCategorical },
}>
```

By the time I was adding tick configuration, this was starting to get repetitive. So I looked for ways to reduce the verbosity. I introduced this helper, to be reused for all `configureX` functions whose argument or config signatures that vary by axis and chart type. It has two modes, the default mode where both axes are required like `XY<any>`, and a mode where they may be omitted like `Partial<XY<any>>` (as for user-facing arguments). Also, as you can see with the definition of `type Categories = PerAxisConfigByChartType<never, string[]>`, we can set one of the axes to be omitted by using `never`.

```ts
// When the per-axis type is never, that axis must be omitted.
type XYOmitNever<X, Y> =
  ([X] extends [never] ? {} : { x: X })
  & ([Y] extends [never] ? {} : { y: Y })

export type PerAxisConfigByChartType<
  Default,
  Categorical,
  AxisKeyMode extends "required" | "optional" = "required"
> = HasAllKeys<ChartType, {
  default: XYOmitNever<Default, Default>,
  categoricalX: XYOmitNever<Categorical, Default>,
  categoricalY: XYOmitNever<Default, Categorical>,
  categoricalXY: XYOmitNever<Categorical, Categorical>,
} extends infer Types ? {
  [T in keyof Types]: AxisKeyMode extends "optional"
    ? Partial<Types[T]> // In 'optional' mode, each axis can be omitted (if it isn't already omitted by XYOmitNever).
    : Types[T]
} : never>
```