### PR TITLE
Draw lines at edges of bands

### DIFF
--- a/src/Chart/visual/Visual.ts
+++ b/src/Chart/visual/Visual.ts
@@ -41,7 +41,7 @@ export class Visual<M, T extends ChartType, Flags extends CurrFlags> {
       .append("svg:clipPath")
       .attr("id", clipPathId) as any as D3Selection<SVGClipPathElement>;
     const { x, y } = getInner(bounds);
-    const buffer = originLineStrokeWidth / 2; // Add a buffer to the clip path to ensure the origin line is not clipped
+    const buffer = 1; // Add a buffer to the clip path to ensure origin lines and band border lines are not clipped
     clipPath.append("svg:rect")
       .attr("width", x.end - x.start + buffer * 2)
       .attr("height", y.end - y.start + buffer * 2)

--- a/src/Chart/visual/layers/AxesLayer.ts
+++ b/src/Chart/visual/layers/AxesLayer.ts
@@ -69,7 +69,8 @@ export class AxesLayer<M> extends Layer<M, null> {
       this.zoomCallbacks.push(zoom);
     }
 
-    this.drawOriginLine(axis, scale, addZoom);
+    // Draw origin line
+    this.drawPerpendicularLine(axis, scale, addZoom, 0, originLineStrokeWidth, "darkgrey");
   };
 
   private drawCategorical = (axis: XorY, scaleCategorical: ScaleCategorical) => {
@@ -94,17 +95,28 @@ export class AxesLayer<M> extends Layer<M, null> {
     const numericalScales = scaleCategorical.categories; // Each band's "inner" scale
     Object.entries(numericalScales).forEach(([_, scale]) => {
       this.drawNumerical(axis, scale, false);
+      // Draw lines at edges of each band, except if an origin line is already drawn there.
+      const [bandStartDC, bandEndDC] = scale.domain().filter(d => d !== 0);
+      if (bandStartDC) this.drawPerpendicularLine(axis, scale, false, bandStartDC);
+      if (bandEndDC && bandScale.paddingInner() !== 0) this.drawPerpendicularLine(axis, scale, false, bandEndDC);
     });
   };
 
-  // Draw a line at the origin (where axis value is 0) of a numerical scale.
+  // Draw a line perpendicular to the specified axis at the given position in data coordinates.
   // This line will be made up of 1 or more segments, since if the other axis is categorical,
   // inter-segment gaps are required for skipping over the padding of the categorical bands.
-  private drawOriginLine = (axis: XorY, numScale: ScaleNumeric, addZoom: boolean) => {
-    const originSC = numScale(0);
+  private drawPerpendicularLine = (
+    axis: XorY,
+    numScale: ScaleNumeric,
+    addZoom: boolean,
+    positionDC: number,
+    strokeWidthPx: number = 0.5,
+    color: string = "black",
+  ) => {
+    const positionSC = numScale(positionDC);
     const [minSC, maxSC] = numScale.range().sort((a, b) => a - b);
-    // If origin is out of range, don't draw the line. Otherwise we might draw a line onto another band.
-    if (originSC < minSC || originSC > maxSC) return;
+    // If outside of range, don't draw the line. Otherwise we might draw a line onto another band.
+    if (positionSC < minSC || positionSC > maxSC) return;
 
     // Get all the numerical scales for the other axis, termed the 'foreign axis'.
     // Categorical axes contain multiple numerical scales; non-categorical axes contain exactly one.
@@ -117,26 +129,26 @@ export class AxesLayer<M> extends Layer<M, null> {
 
     foreignNumScales.forEach(scale => {
       const lineSegment = this.coreLayers[CoreLayer.BaseLayer].append("g").append("line")
-        .attr(`${axis}1`, originSC)
-        .attr(`${axis}2`, originSC)
+        .attr(`${axis}1`, positionSC)
+        .attr(`${axis}2`, positionSC)
         .attr(`${foreignAxis}1`, scale.range()[0])
         .attr(`${foreignAxis}2`, scale.range()[1])
-        .style("stroke", "darkgrey").style("stroke-width", originLineStrokeWidth);
+        .style("stroke", color).style("stroke-width", strokeWidthPx);
 
       if (addZoom) {
         const zoom = async () => {
-          const newOriginSC = numScale(0);
+          const newPositionSC = numScale(positionDC);
           await lineSegment.transition()
             .duration(animationDuration)
-            .attr(`${axis}1`, newOriginSC)
-            .attr(`${axis}2`, newOriginSC)
-            .style("stroke-width", originLineStrokeWidth)
+            .attr(`${axis}1`, newPositionSC)
+            .attr(`${axis}2`, newPositionSC)
+            .style("stroke-width", strokeWidthPx)
             .end();
         };
         this.zoomCallbacks.push(zoom);
       }
     });
-  }
+  };
 
   private addLabels = () => {
     const { getHtmlId, bounds } = this.prevOutput.baseState;
@@ -164,5 +176,5 @@ export class AxesLayer<M> extends Layer<M, null> {
           .attr("y", inner.y.end + padding)
       }
     });
-  }
+  };
 }

--- a/src/Chart/visual/layers/AxesLayer.ts
+++ b/src/Chart/visual/layers/AxesLayer.ts
@@ -8,7 +8,6 @@ import { getInner } from "@/Chart/base/utils";
 import { doXY } from "@/helpers";
 
 const animationDuration = 350;
-export const originLineStrokeWidth = 1;
 
 export class AxesLayer<M> extends Layer<M, null> {
   private zoomCallbacks: (() => Promise<void>)[] = [];
@@ -70,7 +69,7 @@ export class AxesLayer<M> extends Layer<M, null> {
     }
 
     // Draw origin line
-    this.drawPerpendicularLine(axis, scale, addZoom, 0, originLineStrokeWidth, "darkgrey");
+    this.drawPerpendicularLine(axis, scale, addZoom, 0);
   };
 
   private drawCategorical = (axis: XorY, scaleCategorical: ScaleCategorical) => {
@@ -82,7 +81,8 @@ export class AxesLayer<M> extends Layer<M, null> {
     const axisConstructor = axis === "x" ? d3.axisBottom : d3.axisLeft;
     const tickPadding = 30; // This will become a configurable option.
     
-    const bandScale = scaleCategorical.scale; // The main, "outer" scale, containing all the bands
+    // Process the main, "outer" scale, containing all the bands
+    const bandScale = scaleCategorical.scale;
     const categoricalAxis = axisConstructor(bandScale).tickPadding(tickPadding);
     const axisGElement = this.coreLayers[CoreLayer.Svg]
       .append("g")
@@ -92,13 +92,29 @@ export class AxesLayer<M> extends Layer<M, null> {
       .call(categoricalAxis);
     axisGElement.select(".domain").style("stroke-opacity", 0);
 
-    const numericalScales = scaleCategorical.categories; // Each band's "inner" scale
-    Object.entries(numericalScales).forEach(([_, scale]) => {
-      this.drawNumerical(axis, scale, false);
-      // Draw lines at edges of each band, except if an origin line is already drawn there.
-      const [bandStartDC, bandEndDC] = scale.domain().filter(d => d !== 0);
-      if (bandStartDC) this.drawPerpendicularLine(axis, scale, false, bandStartDC);
-      if (bandEndDC && bandScale.paddingInner() !== 0) this.drawPerpendicularLine(axis, scale, false, bandEndDC);
+    // Process each band's "inner" scale, which is a numerical scale
+    Object.entries(scaleCategorical.categories).forEach(([_, innerNumScale]) => {
+      this.drawNumerical(axis, innerNumScale, false);
+
+      // Draw each band's edge lines. The number of edges we draw lines on depends on whether there is inner padding.
+      const [bandStartDC, bandEndDC] = innerNumScale.domain();
+      // Always draw a line on the starting edge of each band.
+      this.drawPerpendicularLine(axis, innerNumScale, false, bandStartDC);
+
+      // Draw lines on all borders of each band when there is padding between bands.
+      if (bandScale.paddingInner() !== 0) {
+        this.drawPerpendicularLine(axis, innerNumScale, false, bandEndDC);
+
+        // Draw the border lines that are parallel to current axis (i.e. perpendicular to foreign axis).
+        // If the foreign scale is categorical, those lines will be drawn when that scale is processed,
+        // so we only need to draw them here if the foreign scale is numerical.
+        const foreignScaleIsNumerical = ["default", (axis === "x" ? "categoricalX" : "categoricalY")].includes(this.prevOutput.chartType);
+        if (foreignScaleIsNumerical) {
+          const foreignAxis = axis === "x" ? "y" : "x";
+          const foreignScale = this.prevOutput.configState.scales[foreignAxis] as ScaleNumeric;
+          foreignScale.domain().forEach(extentDC => this.drawPerpendicularLine(foreignAxis, foreignScale, false, extentDC));
+        }
+      }
     });
   };
 
@@ -110,7 +126,7 @@ export class AxesLayer<M> extends Layer<M, null> {
     numScale: ScaleNumeric,
     addZoom: boolean,
     positionDC: number,
-    strokeWidthPx: number = 0.5,
+    strokeWidthPx: number = 1,
     color: string = "black",
   ) => {
     const positionSC = numScale(positionDC);

--- a/src/demo/NewSkadiChart.vue
+++ b/src/demo/NewSkadiChart.vue
@@ -157,7 +157,7 @@ const renderChart = (chartType: ChartType) => {
     .startConfig()
     .configureAxes({
       x: { label: { text: "Time" } },
-      y: { label: { text: "Y Category" }, innerPadding: 0.1 },
+      y: { label: { text: "Y Category" }, innerPadding: 0 },
     })
     .configureCategories({
       y: ["Category A", "Category B"],


### PR DESCRIPTION
This brings us to feature parity with legacy skadi-chart for band scales.

The logic is that we should draw 1 boundary line between bands, except in the case where there is inner padding, in which case we draw 2 boundary lines.

Implemented by repurposing drawOriginLine to be more generic: it is now capable of drawing a line perpendicular to any data coord, not just 0.